### PR TITLE
Escape record fields for safety

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,15 +580,23 @@
         container.innerHTML = "<p>No records found.</p>";
         return;
       }
+      // Escape special characters to prevent HTML injection in record fields
+      const escapeHtml = (str) =>
+        String(str)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/'/g, '&#39;')
+          .replace(/"/g, '&quot;');
       let html = "<table><tr><th>Timestamp</th><th>Badge</th><th>Name</th><th>Equipment Barcodes</th><th>Equipment Names</th><th>Action</th></tr>";
       recArray.forEach(rec => {
         html += `<tr>
-          <td>${rec.timestamp}</td>
-          <td>${rec.badge}</td>
-          <td>${rec.employeeName}</td>
-          <td>${rec.equipmentBarcodes.join('; ')}</td>
-          <td>${rec.equipmentNames.join('; ')}</td>
-          <td>${rec.action}</td>
+          <td>${escapeHtml(rec.timestamp)}</td>
+          <td>${escapeHtml(rec.badge)}</td>
+          <td>${escapeHtml(rec.employeeName)}</td>
+          <td>${escapeHtml(rec.equipmentBarcodes.join('; '))}</td>
+          <td>${escapeHtml(rec.equipmentNames.join('; '))}</td>
+          <td>${escapeHtml(rec.action)}</td>
         </tr>`;
       });
       html += "</table>";


### PR DESCRIPTION
## Summary
- escape timestamps, user info, and equipment fields before injecting into records table
- introduce `escapeHtml` helper to encode special characters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896a06b0d3c832ba1047870f6fe110c