### PR TITLE
Add notification helpers for user feedback

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -89,6 +89,16 @@
       text-align: center;
       display: none;
     }
+    #notifications.success {
+      background-color: #d4edda;
+      border: 1px solid #c3e6cb;
+      color: #155724;
+    }
+    #notifications.error {
+      background-color: #f8d7da;
+      border: 1px solid #f5c6cb;
+      color: #721c24;
+    }
 
     /* Navigation */
     nav {


### PR DESCRIPTION
## Summary
- Add reusable success/error notification helpers with optional auto-hide
- Replace all `alert()` usages with unified notifications
- Introduce success and error styles for `#notifications` for consistent feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897eb42409c832ba89dff92af1ab7a8