### PR TITLE
Refactor inline visibility to CSS classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
             <input type="text" name="equipment" placeholder="Scan Equipment Barcode" required>
             <span class="equipmentNameDisplay"></span>
           </div>
-          <button type="button" class="removeEquipment" style="display: none;">Remove</button>
+          <button type="button" class="removeEquipment hidden">Remove</button>
         </div>
       </div>
       <button type="button" id="addEquipmentBtn">Add Another Barcode</button>
@@ -94,19 +94,19 @@
     <!-- New Import/Export Section -->
     <hr>
     <h2>Inventory Import/Export</h2>
-    <div style="margin-bottom:15px;">
+      <div class="mb-15">
       <h3>Employees</h3>
       <button type="button" class="btn-inline" id="exportEmployeesBtn">Export Employees to CSV</button>
       <button type="button" class="btn-inline" id="importEmployeesBtn">Import Employees CSV</button>
-      <!-- Hidden file input for employees -->
-      <input type="file" id="importEmployeesFile" accept=".csv" style="display:none;">
+        <!-- Hidden file input for employees -->
+        <input type="file" id="importEmployeesFile" accept=".csv" class="hidden">
     </div>
-    <div style="margin-bottom:15px;">
+      <div class="mb-15">
       <h3>Equipment</h3>
       <button type="button" class="btn-inline" id="exportEquipmentBtn">Export Equipment to CSV</button>
       <button type="button" class="btn-inline" id="importEquipmentBtn">Import Equipment CSV</button>
-      <!-- Hidden file input for equipment -->
-      <input type="file" id="importEquipmentFile" accept=".csv" style="display:none;">
+        <!-- Hidden file input for equipment -->
+        <input type="file" id="importEquipmentFile" accept=".csv" class="hidden">
     </div>
   </section>
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -20,11 +20,11 @@ function showNotification(message, type, delay = 3000) {
   tempNotificationActive = true;
   notificationDiv.className = type;
   notificationDiv.textContent = message;
-  notificationDiv.style.display = 'block';
+  notificationDiv.classList.add('visible');
 
   if (delay > 0) {
     notificationTimer = setTimeout(() => {
-      notificationDiv.style.display = 'none';
+      notificationDiv.classList.remove('visible');
       notificationDiv.className = '';
       notificationDiv.textContent = '';
       tempNotificationActive = false;
@@ -46,6 +46,7 @@ function updateNotifications() {
 
   const notificationDiv = document.getElementById('notifications');
   notificationDiv.className = '';
+  notificationDiv.classList.remove('visible');
   const status = {};
   records.forEach(rec => {
     rec.equipmentBarcodes.forEach(code => {
@@ -65,10 +66,11 @@ function updateNotifications() {
     }
   }
   if (overdue.length > 0) {
-    notificationDiv.style.display = "block";
     notificationDiv.textContent = "Overdue Equipment: " + overdue.join(", ");
+    notificationDiv.classList.add('visible');
   } else {
-    notificationDiv.style.display = "none";
+    notificationDiv.textContent = "";
+    notificationDiv.classList.remove('visible');
   }
 }
 updateNotifications();
@@ -120,7 +122,7 @@ function addEquipmentField() {
 
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.className = 'removeEquipment';
+  removeBtn.className = 'removeEquipment hidden';
   removeBtn.textContent = 'Remove';
   removeBtn.addEventListener('click', () => removeEquipmentField(removeBtn));
 
@@ -142,7 +144,11 @@ function updateRemoveButtons() {
   const items = document.querySelectorAll('#equipmentList .equipment-item');
   items.forEach(item => {
     const btn = item.querySelector('.removeEquipment');
-    btn.style.display = (items.length > 1) ? 'block' : 'none';
+    if (items.length > 1) {
+      btn.classList.remove('hidden');
+    } else {
+      btn.classList.add('hidden');
+    }
   });
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -58,6 +58,8 @@
       padding: 10px 15px;
     }
     .hidden { display: none; }
+    .mb-15 { margin-bottom: 15px; }
+    #notifications.visible { display: block; }
 
     /* Header / Logo */
     .site-header {


### PR DESCRIPTION
## Summary
- Replace inline display and margin styles in index.html with reusable `hidden` and `mb-15` classes
- Add spacing and visibility classes in main stylesheet
- Toggle visibility via CSS classes in JavaScript instead of `style.display`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897f1361898832badabff5e5d53b077