### PR TITLE
Handle quoted fields in CSV imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
       document.getElementById('favicon').href = fav;
     });
   </script>
+  <script src="scripts/csvParser.js"></script>
   <script src="scripts/app.js"></script>
 </body>
 </html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -423,7 +423,7 @@ function handleImportEmployees(event) {
     for (let i = 1; i < lines.length; i++) {
       const line = lines[i].trim();
       if (line === "") continue;
-      const parts = line.split(",");
+      const parts = parseCSVLine(line);
       let badge = parts[0].replace(/^"|"$/g, '').trim();
       let name = parts[1].replace(/^"|"$/g, '').trim();
       if (badge && name) {
@@ -455,7 +455,7 @@ function handleImportEquipment(event) {
     for (let i = 1; i < lines.length; i++) {
       const line = lines[i].trim();
       if (line === "") continue;
-      const parts = line.split(",");
+      const parts = parseCSVLine(line);
       let serial = parts[0].replace(/^"|"$/g, '').trim();
       let name = parts[1].replace(/^"|"$/g, '').trim();
       if (serial && name) {

--- a/scripts/csvParser.js
+++ b/scripts/csvParser.js
@@ -1,0 +1,27 @@
+function parseCSVLine(line) {
+  const result = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { parseCSVLine };
+}

--- a/tests/csvParser.test.js
+++ b/tests/csvParser.test.js
@@ -1,0 +1,11 @@
+const { parseCSVLine } = require('../scripts/csvParser');
+
+describe('parseCSVLine', () => {
+  test('parses simple CSV line', () => {
+    expect(parseCSVLine('123,John Doe')).toEqual(['123', 'John Doe']);
+  });
+
+  test('handles quoted commas', () => {
+    expect(parseCSVLine('"123","Doe, John"')).toEqual(['123', 'Doe, John']);
+  });
+});


### PR DESCRIPTION
## Summary
- Add lightweight CSV parser that respects quoted fields
- Integrate parser into import logic for employees and equipment
- Include unit tests for CSV lines with quoted commas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897fdb5c85c832b9e1355c122fc23fb