### PR TITLE
Handle missing fields in record filtering

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -349,14 +349,18 @@ function filterRecords() {
   const date = document.getElementById('recordDate').value;
   let filtered = records;
   if (search) {
-    filtered = filtered.filter(rec =>
-      rec.badge.toLowerCase().includes(search) ||
-      rec.employeeName.toLowerCase().includes(search)
-    );
+    filtered = filtered.filter(rec => {
+      const badge = String(rec?.badge ?? "");
+      const name = String(rec?.employeeName ?? "");
+      return badge.toLowerCase().includes(search) ||
+             name.toLowerCase().includes(search);
+    });
   }
   if (equipSearch) {
     filtered = filtered.filter(rec => {
-      const combinedEquip = rec.equipmentBarcodes.join(" ").toLowerCase() + " " + rec.equipmentNames.join(" ").toLowerCase();
+      const barcodes = (rec?.equipmentBarcodes ?? []).join(" ").toLowerCase();
+      const names = (rec?.equipmentNames ?? []).join(" ").toLowerCase();
+      const combinedEquip = `${barcodes} ${names}`.trim();
       return combinedEquip.includes(equipSearch);
     });
   }

--- a/tests/filterRecords.test.js
+++ b/tests/filterRecords.test.js
@@ -73,4 +73,43 @@ describe('filterRecords', () => {
     expect(rows[1].children[1].textContent).toBe('456');
     expect(rows[1].children[2].textContent).toBe('Bob');
   });
+
+  test('Search handles numeric badge and name fields', () => {
+    const records = [
+      { timestamp: 't1', recordDate: '2023-01-01', badge: 789, employeeName: 1001, equipmentBarcodes: ['EQ1'], equipmentNames: ['Laptop'], action: 'Check-Out' }
+    ];
+    const win = loadDom(records);
+
+    document.getElementById('recordSearch').value = '789';
+    win.filterRecords();
+    let rows = document.querySelectorAll('#recordsTable table tr');
+    expect(rows).toHaveLength(2);
+    expect(rows[1].children[1].textContent).toBe('789');
+
+    document.getElementById('recordSearch').value = '1001';
+    win.filterRecords();
+    rows = document.querySelectorAll('#recordsTable table tr');
+    expect(rows).toHaveLength(2);
+    expect(rows[1].children[2].textContent).toBe('1001');
+  });
+
+  test('Search handles records missing badge or name', () => {
+    const records = [
+      { timestamp: 't1', recordDate: '2023-01-01', badge: '123', equipmentBarcodes: ['EQ1'], equipmentNames: ['Laptop'], action: 'Check-Out' },
+      { timestamp: 't2', recordDate: '2023-01-01', employeeName: 'Daisy', equipmentBarcodes: ['EQ2'], equipmentNames: ['Tablet'], action: 'Check-In' }
+    ];
+    const win = loadDom(records);
+
+    document.getElementById('recordSearch').value = '123';
+    expect(() => win.filterRecords()).not.toThrow();
+    let rows = document.querySelectorAll('#recordsTable table tr');
+    expect(rows).toHaveLength(2);
+    expect(rows[1].children[1].textContent).toBe('123');
+
+    document.getElementById('recordSearch').value = 'daisy';
+    expect(() => win.filterRecords()).not.toThrow();
+    rows = document.querySelectorAll('#recordsTable table tr');
+    expect(rows).toHaveLength(2);
+    expect(rows[1].children[2].textContent).toBe('Daisy');
+  });
 });


### PR DESCRIPTION
## Summary
- Safely convert badge and employee name fields in `filterRecords` using `String()` and fallbacks to avoid errors on missing or non-string data.
- Guard equipment field lookups with defaults to prevent runtime exceptions when arrays are absent.
- Extend tests to cover numeric badge/name values and records missing those fields.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689807b6c84c832b84b4161814adef25