### PR TITLE
Handle corrupt localStorage values

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -7,6 +7,7 @@ function loadFromStorage(key, fallback) {
   } catch (e) {
     console.warn(`Failed to parse ${key} from storage, resetting to defaults`, e);
     setTimeout(() => showError(`Stored data for ${key} was invalid and has been reset.`), 0);
+    saveToStorage(key, fallback);
     return fallback;
   }
 }

--- a/tests/loadFromStorage.test.js
+++ b/tests/loadFromStorage.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+const script = fs.readFileSync(path.resolve(__dirname, '../scripts/app.js'), 'utf8');
+
+function setupDom() {
+  const dom = new JSDOM(html, { url: 'http://localhost', runScripts: 'dangerously' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.localStorage = window.localStorage;
+  window.eval(script);
+  return window;
+}
+
+afterEach(() => {
+  delete global.window;
+  delete global.document;
+  delete global.localStorage;
+});
+
+test('loadFromStorage clears corrupt data and persists defaults', () => {
+  jest.useFakeTimers();
+  const win = setupDom();
+  localStorage.setItem('records', 'not-json');
+  const result = win.loadFromStorage('records', []);
+  expect(result).toEqual([]);
+  expect(localStorage.getItem('records')).toBe('[]');
+  jest.runAllTimers();
+  jest.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- Resave defaults to localStorage when stored JSON is invalid
- Add unit test ensuring corrupt storage is reset and prevent timer leak

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68980eb6a004832b896f81de8171b517