### PR TITLE
Escape CR and LF in CSV export

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -21,7 +21,7 @@ function saveToStorage(key, data) {
 }
 
 function csvEscape(value) {
-  return String(value).replace(/"/g, '""');
+  return String(value).replace(/["\r\n]/g, c => c + c);
 }
 
 /* ---------- Notification System ---------- */

--- a/tests/exportCSV.test.js
+++ b/tests/exportCSV.test.js
@@ -67,3 +67,45 @@ test('exportRecordsCSV escapes quotes in fields', () => {
   expect(row).toBe('"2023-01-01T00:00:00","1","John ""JJ"" Doe","EQ1","Hammer ""XL""","Check-Out"');
   spy.mockRestore();
 });
+
+test('exportEmployeesCSV doubles newlines in names', () => {
+  const win = setupDom({ employees: { '1': 'John\r\nDoe' } });
+  const spy = jest.spyOn(document.body, 'appendChild');
+  win.exportEmployeesCSV();
+  const link = spy.mock.calls[0][0];
+  const csv = decodeURI(link.href).split('charset=utf-8,')[1];
+  const expected = `Badge ID,Employee Name\n"1","John\r\r\n\nDoe"\n`;
+  expect(csv).toBe(expected);
+  spy.mockRestore();
+});
+
+test('exportEquipmentCSV doubles newlines in names', () => {
+  const win = setupDom({ equipmentItems: { 'EQ1': 'Hammer\r\nXL' } });
+  const spy = jest.spyOn(document.body, 'appendChild');
+  win.exportEquipmentCSV();
+  const link = spy.mock.calls[0][0];
+  const csv = decodeURI(link.href).split('charset=utf-8,')[1];
+  const expected = `Equipment Serial,Equipment Name\n"EQ1","Hammer\r\r\n\nXL"\n`;
+  expect(csv).toBe(expected);
+  spy.mockRestore();
+});
+
+test('exportRecordsCSV doubles newlines in fields', () => {
+  const records = [{
+    timestamp: '2023-01-01T00:00:00',
+    badge: '1',
+    employeeName: 'John\r\nDoe',
+    equipmentBarcodes: ['EQ1'],
+    equipmentNames: ['Hammer\r\nXL'],
+    action: 'Check-Out',
+    recordDate: '2023-01-01'
+  }];
+  const win = setupDom({ records });
+  const spy = jest.spyOn(document.body, 'appendChild');
+  win.exportRecordsCSV();
+  const link = spy.mock.calls[0][0];
+  const csv = decodeURI(link.href).split('charset=utf-8,')[1];
+  const expected = `Timestamp,Employee Badge ID,Employee Name,Equipment Barcodes,Equipment Names,Action\n"2023-01-01T00:00:00","1","John\r\r\n\nDoe","EQ1","Hammer\r\r\n\nXL","Check-Out"`;
+  expect(csv).toBe(expected);
+  spy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- escape carriage return and line feed characters in csvEscape
- test CSV export for fields containing newlines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980ffdeea0832b9363af87a042f8a4