### PR TITLE
Handle Windows line endings in CSV parser

### DIFF
--- a/scripts/csvParser.js
+++ b/scripts/csvParser.js
@@ -1,4 +1,7 @@
 function parseCSVLine(line) {
+  if (line.endsWith('\r')) {
+    line = line.slice(0, -1);
+  }
   const result = [];
   let current = '';
   let inQuotes = false;

--- a/tests/csvParser.test.js
+++ b/tests/csvParser.test.js
@@ -8,4 +8,9 @@ describe('parseCSVLine', () => {
   test('handles quoted commas', () => {
     expect(parseCSVLine('"123","Doe, John"')).toEqual(['123', 'Doe, John']);
   });
+
+  test('parses line ending with \r\n', () => {
+    const line = '123,John Doe\r\n'.split('\n')[0];
+    expect(parseCSVLine(line)).toEqual(['123', 'John Doe']);
+  });
 });


### PR DESCRIPTION
## Summary
- Strip trailing `\r` before parsing CSV lines to handle Windows line endings
- Test parsing lines ending with CRLF sequences

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689811d6b39c832b8bbf953b7f67255e