### PR TITLE
Handle malformed CSV imports with error checks and tests

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -438,6 +438,10 @@ function handleImportEmployees(event) {
   }
   const file = input.files[0];
   const reader = new FileReader();
+  reader.onerror = function() {
+    showError("Failed to read employees file.");
+    input.value = "";
+  };
   reader.onload = function(e) {
     const text = e.target.result;
     const lines = text.split("\n");
@@ -445,6 +449,10 @@ function handleImportEmployees(event) {
       const line = lines[i].trim();
       if (line === "") continue;
       const parts = parseCSVLine(line);
+      if (parts.length < 2) {
+        showError(`Skipping malformed line ${i + 1}: ${line}`);
+        continue;
+      }
       let badge = parts[0].replace(/^"|"$/g, '').trim();
       let name = parts[1].replace(/^"|"$/g, '').trim();
       if (badge && name) {
@@ -470,6 +478,10 @@ function handleImportEquipment(event) {
   }
   const file = input.files[0];
   const reader = new FileReader();
+  reader.onerror = function() {
+    showError("Failed to read equipment file.");
+    input.value = "";
+  };
   reader.onload = function(e) {
     const text = e.target.result;
     const lines = text.split("\n");
@@ -477,6 +489,10 @@ function handleImportEquipment(event) {
       const line = lines[i].trim();
       if (line === "") continue;
       const parts = parseCSVLine(line);
+      if (parts.length < 2) {
+        showError(`Skipping malformed line ${i + 1}: ${line}`);
+        continue;
+      }
       let serial = parts[0].replace(/^"|"$/g, '').trim();
       let name = parts[1].replace(/^"|"$/g, '').trim();
       if (serial && name) {

--- a/tests/importHandlers.test.js
+++ b/tests/importHandlers.test.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+const parserScript = fs.readFileSync(path.resolve(__dirname, '../scripts/csvParser.js'), 'utf8');
+const appScript = fs.readFileSync(path.resolve(__dirname, '../scripts/app.js'), 'utf8');
+
+function setupDom() {
+  const dom = new JSDOM(html, { url: 'http://localhost', runScripts: 'dangerously' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.localStorage = window.localStorage;
+  window.eval(parserScript);
+  window.eval(appScript);
+  return window;
+}
+
+afterEach(() => {
+  delete global.window;
+  delete global.document;
+  delete global.localStorage;
+});
+
+test('handleImportEmployees skips malformed lines', () => {
+  const win = setupDom();
+  win.showError = jest.fn();
+  win.showSuccess = jest.fn();
+  win.displayEmployeeList = jest.fn();
+  class MockFileReader {
+    readAsText(file) {
+      this.onload && this.onload({ target: { result: file.text } });
+    }
+  }
+  win.FileReader = MockFileReader;
+  const event = { target: { files: [ { text: 'Badge ID,Employee Name\n123,John\n456' } ], value: '' } };
+  win.handleImportEmployees(event);
+  const stored = JSON.parse(localStorage.getItem('employees'));
+  expect(stored).toEqual({ '123': 'John' });
+  expect(win.showError).toHaveBeenCalledWith(expect.stringContaining('line 3'));
+});
+
+test('handleImportEquipment skips malformed lines', () => {
+  const win = setupDom();
+  win.showError = jest.fn();
+  win.showSuccess = jest.fn();
+  win.displayEquipmentListAdmin = jest.fn();
+  class MockFileReader {
+    readAsText(file) {
+      this.onload && this.onload({ target: { result: file.text } });
+    }
+  }
+  win.FileReader = MockFileReader;
+  const event = { target: { files: [ { text: 'Equipment Serial,Equipment Name\nEQ1,Hammer\nEQ2' } ], value: '' } };
+  win.handleImportEquipment(event);
+  const stored = JSON.parse(localStorage.getItem('equipmentItems'));
+  expect(stored).toEqual({ 'EQ1': 'Hammer' });
+  expect(win.showError).toHaveBeenCalledWith(expect.stringContaining('line 3'));
+});
+
+test('handleImportEmployees surfaces read errors', () => {
+  const win = setupDom();
+  win.showError = jest.fn();
+  win.showSuccess = jest.fn();
+  win.displayEmployeeList = jest.fn();
+  class MockFileReader {
+    readAsText(file) {
+      this.onerror && this.onerror(new Error('fail'));
+    }
+  }
+  win.FileReader = MockFileReader;
+  const event = { target: { files: [ { text: 'ignored', fail: true } ], value: '' } };
+  win.handleImportEmployees(event);
+  expect(win.showError).toHaveBeenCalled();
+  expect(win.showSuccess).not.toHaveBeenCalled();
+  expect(localStorage.getItem('employees')).toBeNull();
+});


### PR DESCRIPTION
## Summary
- Add FileReader error callbacks and malformed line checks to employee and equipment CSV import handlers
- Skip malformed CSV lines and surface errors to users
- Add unit tests for malformed CSV import and reader errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68981308e100832ba720d84d1a7becb6