### PR TITLE
Ensure CSV export omits undefined values

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -387,7 +387,12 @@ function exportRecordsCSV() {
   }
   const header = "Timestamp,Employee Badge ID,Employee Name,Equipment Barcodes,Equipment Names,Action\n";
   const rows = records.map(rec =>
-    `"${csvEscape(rec.timestamp)}","${csvEscape(rec.badge)}","${csvEscape(rec.employeeName)}","${csvEscape(rec.equipmentBarcodes.join('; '))}","${csvEscape(rec.equipmentNames.join('; '))}","${csvEscape(rec.action)}"`
+    `"${csvEscape(rec.timestamp ?? '')}",` +
+    `"${csvEscape(rec.badge ?? '')}",` +
+    `"${csvEscape(rec.employeeName ?? '')}",` +
+    `"${csvEscape((rec.equipmentBarcodes ?? []).join('; ') ?? '')}",` +
+    `"${csvEscape((rec.equipmentNames ?? []).join('; ') ?? '')}",` +
+    `"${csvEscape(rec.action ?? '')}"`
   );
   const csvContent = 'data:text/csv;charset=utf-8,' + header + rows.join("\n");
   const link = document.createElement('a');

--- a/tests/exportCSV.test.js
+++ b/tests/exportCSV.test.js
@@ -109,3 +109,20 @@ test('exportRecordsCSV doubles newlines in fields', () => {
   expect(csv).toBe(expected);
   spy.mockRestore();
 });
+
+test('exportRecordsCSV leaves blank cells for missing fields', () => {
+  const records = [{
+    timestamp: '2023-01-01T00:00:00',
+    equipmentBarcodes: [],
+    equipmentNames: [],
+    recordDate: '2023-01-01'
+  }];
+  const win = setupDom({ records });
+  const spy = jest.spyOn(document.body, 'appendChild');
+  win.exportRecordsCSV();
+  const link = spy.mock.calls[0][0];
+  const csv = decodeURI(link.href).split('charset=utf-8,')[1];
+  const row = csv.split('\n')[1];
+  expect(row).toBe('"2023-01-01T00:00:00","","","","",""');
+  spy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- Default missing record values to empty strings in `exportRecordsCSV`
- Add unit test confirming records with absent fields export blank cells

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68981586ecb4832bbc9ae6c3f14a8674