### PR TITLE
Improve narrow screen layout with responsive media query

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -225,3 +225,25 @@
       white-space: nowrap;
       border: 0;
     }
+
+    @media (max-width: 600px) {
+      .employeeRow,
+      .equipmentRow {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .employeeRow input,
+      .employeeRow button,
+      .equipmentRow input,
+      .equipmentRow button {
+        width: 100%;
+      }
+
+      .records-container,
+      form {
+        max-width: 100%;
+        margin: 10px auto;
+        padding: 10px;
+      }
+    }


### PR DESCRIPTION
## Summary
- Add media query for screens under 600px to stack employee/equipment rows and stretch inputs/buttons
- Reduce form and records container padding/margins for better fit on small viewports

## Testing
- `npm test`
- `node -e "[media query verification script]"`

------
https://chatgpt.com/codex/tasks/task_e_689818e72c54832bbed0951c9092d869