### PR TITLE
Enhance mobile navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   <div id="notifications"></div>
 
   <!-- Navigation -->
+  <button id="navToggle" class="nav-toggle">Menu</button>
   <nav>
     <a href="#" id="navCheckout">Check-Out</a>
     <a href="#" id="navAdmin">Admin</a>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -518,6 +518,14 @@ document.getElementById('navCheckout').addEventListener('click', (e) => { e.prev
 document.getElementById('navAdmin').addEventListener('click', (e) => { e.preventDefault(); showSection('admin'); });
 document.getElementById('navRecords').addEventListener('click', (e) => { e.preventDefault(); showSection('records'); });
 
+const navToggle = document.getElementById('navToggle');
+const nav = document.querySelector('nav');
+if (navToggle && nav) {
+  navToggle.addEventListener('click', () => {
+    nav.classList.toggle('show');
+  });
+}
+
 document.getElementById('badge').addEventListener('input', lookupEmployee);
 
 const initialEquipmentInput = document.querySelector('#equipmentList input[name="equipment"]');

--- a/styles/main.css
+++ b/styles/main.css
@@ -112,7 +112,7 @@
     nav {
       display: flex;
       justify-content: center;
-      flex-wrap: nowrap;
+      flex-wrap: wrap;
       gap: 10px;
       overflow-x: auto;
       margin-bottom: 20px;
@@ -130,6 +130,10 @@
     nav a.active {
       background-color: #e65c00;
       text-decoration: underline;
+    }
+
+    .nav-toggle {
+      display: none;
     }
 
     /* Check-Out Section */
@@ -227,6 +231,23 @@
     }
 
     @media (max-width: 600px) {
+      nav {
+        flex-direction: column;
+        display: none;
+      }
+
+      nav.show {
+        display: flex;
+      }
+
+      nav a {
+        width: 100%;
+      }
+
+      .nav-toggle {
+        display: block;
+      }
+
       .employeeRow,
       .equipmentRow {
         flex-direction: column;


### PR DESCRIPTION
## Summary
- Allow navigation links to wrap and add a toggle button for small screens
- Stack navigation vertically on narrow viewports with full-width links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68981aeab148832bb3914edac64cc177