### PR TITLE
feat: improve records table responsiveness

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -261,6 +261,17 @@
         width: 100%;
       }
 
+      #recordsTable table {
+        display: block;
+        overflow-x: auto;
+      }
+
+      #recordsTable th,
+      #recordsTable td {
+        text-align: left;
+        white-space: normal;
+      }
+
       .records-container,
       form {
         max-width: 100%;


### PR DESCRIPTION
## Summary
- make records table mobile-friendly with a 600px breakpoint
- wrap header and cell text for readability on small screens

## Testing
- `npm test`
- `node - <<'NODE' ...` (JSDOM simulation of records table at 500px width)


------
https://chatgpt.com/codex/tasks/task_e_68981c5c39f8832bbecb54ad1f8575d0