### PR TITLE
Consolidate equipment admin add/remove into list controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FedEx Equipment Check-Out System</title>
   <style>
-    #employeeList .deleteEmployee {
+    #employeeList .deleteEmployee,
+    #equipmentListAdmin .deleteEquipment {
       margin-left: 0.5rem;
       cursor: pointer;
       color: red;
@@ -98,7 +99,6 @@
         <input type="text" id="equipSerial" placeholder="Enter Equipment Serial" required>
       </div>
       <button type="button" id="addEquipmentAdminBtn">Add Equipment</button>
-      <button type="button" id="removeEquipmentAdminBtn">Remove Equipment</button>
     </form>
     <h3>Current Equipment</h3>
     <input type="text" id="equipmentSearch" placeholder="Search equipment">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -322,7 +322,15 @@ function displayEquipmentListAdmin(page = equipmentPage, filter = equipmentFilte
   const start = page * pageSize;
   filtered.slice(start, start + pageSize).forEach(([serial, name]) => {
     const li = document.createElement('li');
-    li.textContent = `${serial}: ${name}`;
+    const textSpan = document.createElement('span');
+    textSpan.textContent = `${serial}: ${name}`;
+    const del = document.createElement('span');
+    del.className = 'deleteEquipment';
+    del.textContent = '❌';
+    del.title = 'Remove Equipment';
+    del.addEventListener('click', () => removeEquipmentAdmin(serial));
+    li.appendChild(textSpan);
+    li.appendChild(del);
     list.appendChild(li);
   });
   equipmentPage = page;
@@ -345,14 +353,12 @@ function addEquipmentAdmin() {
     showError('Please enter both equipment name and serial number!');
   }
 }
-function removeEquipmentAdmin() {
-  const serial = document.getElementById('equipSerial').value.trim();
+function removeEquipmentAdmin(serial) {
   if (serial && equipmentItems[serial]) {
     delete equipmentItems[serial];
     saveToStorage('equipmentItems', equipmentItems);
     showSuccess('Equipment removed successfully!');
     displayEquipmentListAdmin();
-    document.getElementById('equipmentAdminForm').reset();
   } else {
     showError('Invalid equipment serial or equipment not found!');
   }
@@ -581,7 +587,6 @@ if (initialEquipmentInput) {
 document.getElementById('addEquipmentBtn').addEventListener('click', addEquipmentField);
 document.getElementById('addEmployeeBtn').addEventListener('click', addEmployee);
 document.getElementById('addEquipmentAdminBtn').addEventListener('click', addEquipmentAdmin);
-document.getElementById('removeEquipmentAdminBtn').addEventListener('click', removeEquipmentAdmin);
 
 document.getElementById('exportEmployeesBtn').addEventListener('click', exportEmployeesCSV);
 document.getElementById('importEmployeesBtn').addEventListener('click', triggerImportEmployees);


### PR DESCRIPTION
## Summary
- Remove standalone equipment deletion button and extend inline deletion styling to equipment list.
- Render each equipment entry with a delete icon and handle removals via `removeEquipmentAdmin`.
- Drop obsolete remove-equipment event listener, leaving only add-equipment admin handler.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899148e2634832ba1fcc3ca0c666e48