### PR TITLE
Add Import/Export dropdown for admin actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,20 +110,18 @@
     
     <!-- New Import/Export Section -->
     <hr>
-    <h2>Inventory Import/Export</h2>
-      <div class="mb-15">
-      <h3>Employees</h3>
-      <button type="button" class="btn-inline" id="exportEmployeesBtn">Export Employees to CSV</button>
-      <button type="button" class="btn-inline" id="importEmployeesBtn">Import Employees CSV</button>
-        <!-- Hidden file input for employees -->
-        <input type="file" id="importEmployeesFile" accept=".csv" class="hidden">
-    </div>
-      <div class="mb-15">
-      <h3>Equipment</h3>
-      <button type="button" class="btn-inline" id="exportEquipmentBtn">Export Equipment to CSV</button>
-      <button type="button" class="btn-inline" id="importEquipmentBtn">Import Equipment CSV</button>
-        <!-- Hidden file input for equipment -->
-        <input type="file" id="importEquipmentFile" accept=".csv" class="hidden">
+    <div class="mb-15">
+      <div class="dropdown">
+        <button type="button" class="btn-inline" id="importExportBtn">Import/Export</button>
+        <div id="importExportMenu" class="dropdown-menu hidden">
+          <button type="button" id="exportEmployeesAction">Export Employees to CSV</button>
+          <button type="button" id="importEmployeesAction">Import Employees CSV</button>
+          <button type="button" id="exportEquipmentAction">Export Equipment to CSV</button>
+          <button type="button" id="importEquipmentAction">Import Equipment CSV</button>
+        </div>
+      </div>
+      <input type="file" id="importEmployeesFile" accept=".csv" class="hidden">
+      <input type="file" id="importEquipmentFile" accept=".csv" class="hidden">
     </div>
   </section>
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -588,12 +588,29 @@ document.getElementById('addEquipmentBtn').addEventListener('click', addEquipmen
 document.getElementById('addEmployeeBtn').addEventListener('click', addEmployee);
 document.getElementById('addEquipmentAdminBtn').addEventListener('click', addEquipmentAdmin);
 
-document.getElementById('exportEmployeesBtn').addEventListener('click', exportEmployeesCSV);
-document.getElementById('importEmployeesBtn').addEventListener('click', triggerImportEmployees);
-document.getElementById('importEmployeesFile').addEventListener('change', handleImportEmployees);
+const importExportBtn = document.getElementById('importExportBtn');
+const importExportMenu = document.getElementById('importExportMenu');
+importExportBtn.addEventListener('click', () => {
+  importExportMenu.classList.toggle('hidden');
+});
 
-document.getElementById('exportEquipmentBtn').addEventListener('click', exportEquipmentCSV);
-document.getElementById('importEquipmentBtn').addEventListener('click', triggerImportEquipment);
+document.getElementById('exportEmployeesAction').addEventListener('click', () => {
+  exportEmployeesCSV();
+  importExportMenu.classList.add('hidden');
+});
+document.getElementById('importEmployeesAction').addEventListener('click', () => {
+  triggerImportEmployees();
+  importExportMenu.classList.add('hidden');
+});
+document.getElementById('exportEquipmentAction').addEventListener('click', () => {
+  exportEquipmentCSV();
+  importExportMenu.classList.add('hidden');
+});
+document.getElementById('importEquipmentAction').addEventListener('click', () => {
+  triggerImportEquipment();
+  importExportMenu.classList.add('hidden');
+});
+document.getElementById('importEmployeesFile').addEventListener('change', handleImportEmployees);
 document.getElementById('importEquipmentFile').addEventListener('change', handleImportEquipment);
 
 document.getElementById('employeeSearch').addEventListener('input', (e) => {

--- a/styles/main.css
+++ b/styles/main.css
@@ -64,6 +64,32 @@
     }
     .hidden { display: none; }
     .mb-15 { margin-bottom: 0.9375rem; }
+    .dropdown {
+      position: relative;
+      display: inline-block;
+    }
+    .dropdown-menu {
+      position: absolute;
+      background-color: #fff;
+      border: 0.0625rem solid #ccc;
+      padding: 0.3125rem;
+      border-radius: 0.5rem;
+      z-index: 1;
+    }
+    .dropdown-menu.hidden { display: none; }
+    .dropdown-menu button {
+      display: block;
+      width: 100%;
+      margin: 0;
+      padding: 0.3125rem 0.625rem;
+      text-align: left;
+      background: none;
+      border: none;
+      cursor: pointer;
+    }
+    .dropdown-menu button:hover {
+      background-color: #f0f0f0;
+    }
     #notifications.visible { display: block; }
 
     /* Header / Logo */


### PR DESCRIPTION
## Summary
- Group employee and equipment import/export actions under a new `Import/Export` dropdown in the admin section
- Update JavaScript handlers to work with dropdown menu options
- Style dropdown and remove old inline import/export buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689916065424832b970803097271a5d4