### PR TITLE
Improve dropdown menu button text contrast

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -86,9 +86,11 @@
       background: none;
       border: none;
       cursor: pointer;
+      color: #000;
     }
     .dropdown-menu button:hover {
       background-color: #f0f0f0;
+      color: #000;
     }
     #notifications.visible { display: block; }
 


### PR DESCRIPTION
## Summary
- ensure dropdown menu buttons render dark text for readability
- keep text color consistent on hover for accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68991acd149c832bb86b8fd86869e418