### PR TITLE
Handle missing equipment arrays in notifications

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -73,7 +73,7 @@ function updateNotifications() {
   notificationDiv.classList.remove('visible');
   const status = {};
   records.forEach(rec => {
-    rec.equipmentBarcodes.forEach(code => {
+    (rec.equipmentBarcodes || []).forEach(code => {
       if (!status[code]) status[code] = 0;
       if (rec.action === "Check-Out") {
         status[code]++;


### PR DESCRIPTION
## Summary
- Safely iterate over `rec.equipmentBarcodes` in `updateNotifications` by defaulting to an empty array
- Confirmed no `rec.equipmentNames` usage in `updateNotifications`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c0526bb48832bb7a5c4675325a9b2