### PR TITLE
Preserve newline characters in CSV exports

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -28,7 +28,7 @@ function saveToStorage(key, data) {
 }
 
 function csvEscape(value) {
-  return String(value).replace(/["\r\n]/g, c => c + c);
+  return String(value).replace(/"/g, '""');
 }
 
 /* ---------- Notification System ---------- */

--- a/tests/exportCSV.test.js
+++ b/tests/exportCSV.test.js
@@ -50,13 +50,13 @@ test('exportEquipmentCSV escapes quotes in names', () => {
 
 test('exportRecordsCSV escapes quotes in fields', () => {
   const records = [{
-    timestamp: '2023-01-01T00:00:00',
-    badge: '1',
-    employeeName: 'John "JJ" Doe',
-    equipmentBarcodes: ['EQ1'],
-    equipmentNames: ['Hammer "XL"'],
-    action: 'Check-Out',
-    recordDate: '2023-01-01'
+  timestamp: '2023-01-01T00:00:00',
+  badge: '1',
+  employeeName: 'John "JJ" Doe',
+  equipmentBarcodes: ['EQ1'],
+  equipmentNames: ['Hammer "XL"'],
+  action: 'Check-Out',
+  recordDate: '2023-01-01'
   }];
   const win = setupDom({ records });
   const spy = jest.spyOn(document.body, 'appendChild');
@@ -68,29 +68,29 @@ test('exportRecordsCSV escapes quotes in fields', () => {
   spy.mockRestore();
 });
 
-test('exportEmployeesCSV doubles newlines in names', () => {
+test('exportEmployeesCSV preserves newline characters in names', () => {
   const win = setupDom({ employees: { '1': 'John\r\nDoe' } });
   const spy = jest.spyOn(document.body, 'appendChild');
   win.exportEmployeesCSV();
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-  const expected = `Badge ID,Employee Name\n"1","John\r\r\n\nDoe"\n`;
+  const expected = `Badge ID,Employee Name\n"1","John\r\nDoe"\n`;
   expect(csv).toBe(expected);
   spy.mockRestore();
 });
 
-test('exportEquipmentCSV doubles newlines in names', () => {
+test('exportEquipmentCSV preserves newline characters in names', () => {
   const win = setupDom({ equipmentItems: { 'EQ1': 'Hammer\r\nXL' } });
   const spy = jest.spyOn(document.body, 'appendChild');
   win.exportEquipmentCSV();
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-  const expected = `Equipment Serial,Equipment Name\n"EQ1","Hammer\r\r\n\nXL"\n`;
+  const expected = `Equipment Serial,Equipment Name\n"EQ1","Hammer\r\nXL"\n`;
   expect(csv).toBe(expected);
   spy.mockRestore();
 });
 
-test('exportRecordsCSV doubles newlines in fields', () => {
+test('exportRecordsCSV preserves newline characters in fields', () => {
   const records = [{
     timestamp: '2023-01-01T00:00:00',
     badge: '1',
@@ -105,17 +105,17 @@ test('exportRecordsCSV doubles newlines in fields', () => {
   win.exportRecordsCSV();
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-  const expected = `Timestamp,Employee Badge ID,Employee Name,Equipment Barcodes,Equipment Names,Action\n"2023-01-01T00:00:00","1","John\r\r\n\nDoe","EQ1","Hammer\r\r\n\nXL","Check-Out"`;
+  const expected = `Timestamp,Employee Badge ID,Employee Name,Equipment Barcodes,Equipment Names,Action\n"2023-01-01T00:00:00","1","John\r\nDoe","EQ1","Hammer\r\nXL","Check-Out"`;
   expect(csv).toBe(expected);
   spy.mockRestore();
 });
 
 test('exportRecordsCSV leaves blank cells for missing fields', () => {
   const records = [{
-    timestamp: '2023-01-01T00:00:00',
-    equipmentBarcodes: [],
-    equipmentNames: [],
-    recordDate: '2023-01-01'
+  timestamp: '2023-01-01T00:00:00',
+  equipmentBarcodes: [],
+  equipmentNames: [],
+  recordDate: '2023-01-01'
   }];
   const win = setupDom({ records });
   const spy = jest.spyOn(document.body, 'appendChild');


### PR DESCRIPTION
## Summary
- Adjust csvEscape to only double quotes and keep newlines unchanged
- Update CSV export tests to reflect newline-preserving behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c06358e00832b84bf4c284c243e6d