### PR TITLE
Handle optional equipment arrays in record display

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -395,8 +395,8 @@ function displayRecords(recArray) {
           <td>${escapeHtml(rec.timestamp)}</td>
           <td>${escapeHtml(rec.badge)}</td>
           <td>${escapeHtml(rec.employeeName)}</td>
-          <td>${escapeHtml(rec.equipmentBarcodes.join('; '))}</td>
-          <td>${escapeHtml(rec.equipmentNames.join('; '))}</td>
+          <td>${escapeHtml((rec.equipmentBarcodes ?? []).join('; '))}</td>
+          <td>${escapeHtml((rec.equipmentNames ?? []).join('; '))}</td>
           <td>${escapeHtml(rec.action)}</td>
         </tr>`;
   });


### PR DESCRIPTION
## Summary
- Safely join `equipmentBarcodes` and `equipmentNames` in `displayRecords` using nullish coalescing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d62d5ff08832bacfa9546034d65d2