### PR TITLE
Prevent duplicate equipment scans

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -199,9 +199,19 @@ function lookupEquipment(event) {
   display.textContent = equipmentName || "";
 
   if (equipmentName) {
-    input.disabled = true;
     const equipmentList = document.getElementById('equipmentList');
     const inputs = equipmentList.querySelectorAll('input[name="equipment"]');
+
+    for (const other of inputs) {
+      if (other !== input && other.value.trim() === value) {
+        showError('Error: Equipment barcode already entered.');
+        input.value = '';
+        display.textContent = '';
+        return;
+      }
+    }
+
+    input.disabled = true;
     if (inputs[inputs.length - 1] === input) {
       addEquipmentField();
       equipmentList.lastElementChild.querySelector('input[name="equipment"]').focus();

--- a/tests/lookupEquipmentDuplicates.test.js
+++ b/tests/lookupEquipmentDuplicates.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+const script = fs.readFileSync(path.resolve(__dirname, '../scripts/app.js'), 'utf8');
+
+function setupDom() {
+  const dom = new JSDOM(html, { url: 'http://localhost', runScripts: 'dangerously' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.localStorage = window.localStorage;
+  window.alert = jest.fn();
+  localStorage.setItem('employees', JSON.stringify({}));
+  localStorage.setItem('equipmentItems', JSON.stringify({ E1: 'Scanner' }));
+  localStorage.setItem('records', JSON.stringify([]));
+  window.eval(script);
+  return window;
+}
+
+afterEach(() => {
+  delete global.window;
+  delete global.document;
+  delete global.localStorage;
+});
+
+test('duplicate equipment barcode clears input and shows error', () => {
+  jest.useFakeTimers();
+  const win = setupDom();
+  const { document } = win;
+
+  const firstInput = document.getElementById('equipment0');
+  firstInput.value = 'E1';
+  firstInput.dispatchEvent(new win.Event('input', { bubbles: true }));
+  expect(firstInput.disabled).toBe(true);
+
+  const secondInput = document.querySelector('#equipmentList input[name="equipment"]:not([disabled])');
+  const errorSpy = jest.spyOn(win, 'showError');
+  secondInput.value = 'E1';
+  secondInput.dispatchEvent(new win.Event('input', { bubbles: true }));
+
+  expect(errorSpy).toHaveBeenCalled();
+  expect(secondInput.disabled).toBe(false);
+  expect(secondInput.value).toBe('');
+  expect(document.querySelectorAll('#equipmentList input[name="equipment"]').length).toBe(2);
+
+  jest.runAllTimers();
+  jest.useRealTimers();
+});
+


### PR DESCRIPTION
## Summary
- prevent adding duplicate equipment barcodes during checkout
- test duplicate equipment scan behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d643fc810832b8cdc269a6dbc367f