### PR TITLE
Update checkout notifications on record save

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -261,6 +261,7 @@ document.getElementById('checkoutForm').addEventListener('submit', function(e) {
   const record = { timestamp, recordDate, badge, employeeName, equipmentBarcodes, equipmentNames, action };
   records.push(record);
   saveToStorage('records', records);
+  updateNotifications();
   showSuccess('Record saved locally!');
   this.reset();
   document.getElementById('employeeName').textContent = "";


### PR DESCRIPTION
## Summary
- trigger `updateNotifications` immediately after saving records so overdue alerts refresh before success message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d6789a38c832ba814f6f376479622