### PR TITLE
Collapse mobile menu after navigation

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -581,9 +581,24 @@ function handleImportEquipment(event) {
 
 /* ---------- Event Listeners ---------- */
 
-document.getElementById('navCheckout').addEventListener('click', (e) => { e.preventDefault(); showSection('checkout'); });
-document.getElementById('navAdmin').addEventListener('click', (e) => { e.preventDefault(); showSection('admin'); });
-document.getElementById('navRecords').addEventListener('click', (e) => { e.preventDefault(); showSection('records'); });
+document.getElementById('navCheckout').addEventListener('click', (e) => {
+  e.preventDefault();
+  showSection('checkout');
+  nav.classList.remove('show');
+  navToggle.setAttribute('aria-expanded', 'false');
+});
+document.getElementById('navAdmin').addEventListener('click', (e) => {
+  e.preventDefault();
+  showSection('admin');
+  nav.classList.remove('show');
+  navToggle.setAttribute('aria-expanded', 'false');
+});
+document.getElementById('navRecords').addEventListener('click', (e) => {
+  e.preventDefault();
+  showSection('records');
+  nav.classList.remove('show');
+  navToggle.setAttribute('aria-expanded', 'false');
+});
 
 const navToggle = document.getElementById('navToggle');
 const nav = document.getElementById('mainNav');

--- a/tests/navCollapse.test.js
+++ b/tests/navCollapse.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+const script = fs.readFileSync(path.resolve(__dirname, '../scripts/app.js'), 'utf8');
+
+function setupDom() {
+  const dom = new JSDOM(html, { url: 'http://localhost', runScripts: 'dangerously' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.localStorage = window.localStorage;
+  window.alert = jest.fn();
+  localStorage.setItem('employees', JSON.stringify({}));
+  localStorage.setItem('equipmentItems', JSON.stringify({}));
+  localStorage.setItem('records', JSON.stringify([]));
+  window.eval(script);
+  return window;
+}
+
+afterEach(() => {
+  delete global.window;
+  delete global.document;
+  delete global.localStorage;
+});
+
+test('nav collapses when link clicked', () => {
+  const win = setupDom();
+  const nav = win.document.getElementById('mainNav');
+  const navToggle = win.document.getElementById('navToggle');
+  nav.classList.add('show');
+  navToggle.setAttribute('aria-expanded', 'true');
+  win.document.getElementById('navAdmin').click();
+  expect(nav.classList.contains('show')).toBe(false);
+  expect(navToggle.getAttribute('aria-expanded')).toBe('false');
+});


### PR DESCRIPTION
## Summary
- Collapse mobile menu and reset toggle state after navigation links are activated
- Add test covering mobile menu collapse behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d72a398e8832bb1ba17e23617a885