### PR TITLE
Add loading state to import actions

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -561,15 +561,34 @@ function triggerImportEmployees() {
   document.getElementById("importEmployeesFile").click();
 }
 
+function setLoading(button, loading, text = 'Importing...') {
+  if (!button) return;
+  if (loading) {
+    button.disabled = true;
+    button.dataset.originalText = button.textContent;
+    button.textContent = text;
+  } else {
+    button.disabled = false;
+    if (button.dataset.originalText) {
+      button.textContent = button.dataset.originalText;
+      delete button.dataset.originalText;
+    }
+  }
+}
+
 function handleImportEmployees(event) {
   const input = event.target;
+  const button = document.getElementById('importEmployeesAction');
+  setLoading(button, true);
   if (input.files.length === 0) {
+    setLoading(button, false);
     return;
   }
   const file = input.files[0];
   const reader = new FileReader();
   reader.onerror = function() {
-    showError("Failed to read employees file.");
+    showError("Unable to read employees CSV file.");
+    setLoading(button, false);
     input.value = "";
   };
   reader.onload = function(e) {
@@ -590,8 +609,9 @@ function handleImportEmployees(event) {
       }
     }
     saveToStorage("employees", employees);
-    showSuccess("Employees imported successfully!");
+    showSuccess("Employee CSV import completed successfully.");
     displayEmployeeList();
+    setLoading(button, false);
     input.value = "";
   };
   reader.readAsText(file);
@@ -603,13 +623,17 @@ function triggerImportEquipment() {
 
 function handleImportEquipment(event) {
   const input = event.target;
+  const button = document.getElementById('importEquipmentAction');
+  setLoading(button, true);
   if (input.files.length === 0) {
+    setLoading(button, false);
     return;
   }
   const file = input.files[0];
   const reader = new FileReader();
   reader.onerror = function() {
-    showError("Failed to read equipment file.");
+    showError("Unable to read equipment CSV file.");
+    setLoading(button, false);
     input.value = "";
   };
   reader.onload = function(e) {
@@ -630,8 +654,9 @@ function handleImportEquipment(event) {
       }
     }
     saveToStorage("equipmentItems", equipmentItems);
-    showSuccess("Equipment imported successfully!");
+    showSuccess("Equipment CSV import completed successfully.");
     displayEquipmentListAdmin();
+    setLoading(button, false);
     input.value = "";
   };
   reader.readAsText(file);

--- a/tests/importHandlers.test.js
+++ b/tests/importHandlers.test.js
@@ -76,3 +76,45 @@ test('handleImportEmployees surfaces read errors', () => {
   expect(win.showSuccess).not.toHaveBeenCalled();
   expect(localStorage.getItem('employees')).toBeNull();
 });
+
+test('handleImportEmployees shows loading state and restores after success', () => {
+  const win = setupDom();
+  win.showError = jest.fn();
+  win.showSuccess = jest.fn();
+  win.displayEmployeeList = jest.fn();
+  let readerInstance;
+  class MockFileReader {
+    constructor() { readerInstance = this; }
+    readAsText() {}
+  }
+  win.FileReader = MockFileReader;
+  const button = win.document.getElementById('importEmployeesAction');
+  const event = { target: { files: [ { text: 'Badge ID,Employee Name\n123,John' } ], value: '' } };
+  win.handleImportEmployees(event);
+  expect(button.disabled).toBe(true);
+  expect(button.textContent).toBe('Importing...');
+  readerInstance.onload({ target: { result: event.target.files[0].text } });
+  expect(button.disabled).toBe(false);
+  expect(button.textContent).toBe('Import Employees CSV');
+});
+
+test('handleImportEquipment restores button after failure', () => {
+  const win = setupDom();
+  win.showError = jest.fn();
+  win.showSuccess = jest.fn();
+  win.displayEquipmentListAdmin = jest.fn();
+  let readerInstance;
+  class MockFileReader {
+    constructor() { readerInstance = this; }
+    readAsText() {}
+  }
+  win.FileReader = MockFileReader;
+  const button = win.document.getElementById('importEquipmentAction');
+  const event = { target: { files: [ { text: 'ignored' } ], value: '' } };
+  win.handleImportEquipment(event);
+  expect(button.disabled).toBe(true);
+  readerInstance.onerror(new Error('fail'));
+  expect(button.disabled).toBe(false);
+  expect(button.textContent).toBe('Import Equipment CSV');
+  expect(win.showError).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- Disable import buttons and show an `Importing...` indicator during CSV processing
- Restore buttons after import completes or fails
- Clarify success and failure notifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d76bccb14832b8374b6842ed9b1a1