### PR TITLE
Prevent duplicate employee and equipment entries

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -356,6 +356,11 @@ function addEmployee() {
     hasError = true;
   }
   if (hasError) return;
+  if (employees[badge]) {
+    setFieldError(badgeInput, 'Badge ID already exists.');
+    showError('Employee with this badge ID already exists!');
+    return;
+  }
   employees[badge] = name;
   saveToStorage('employees', employees);
   showSuccess('Employee added successfully!');
@@ -422,6 +427,11 @@ function addEquipmentAdmin() {
     hasError = true;
   }
   if (hasError) return;
+  if (equipmentItems[serial]) {
+    setFieldError(serialInput, 'Equipment serial already exists.');
+    showError('Equipment with this serial already exists!');
+    return;
+  }
   equipmentItems[serial] = name;
   saveToStorage('equipmentItems', equipmentItems);
   showSuccess('Equipment added successfully!');


### PR DESCRIPTION
## Summary
- Avoid overwriting existing employee records by checking badge ID uniqueness
- Prevent duplicate equipment entries by enforcing unique serial numbers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4e04efe4832ba6da8bebd98eed7e