### PR TITLE
Add ARIA roles and keyboard navigation for dropdown menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,10 +52,10 @@
       <button type="button" id="addEquipmentBtn">Add Another Barcode</button>
       <label for="actionBtn">Action:</label>
       <div class="dropdown">
-        <button type="button" id="actionBtn" class="btn-inline">Select Action</button>
-        <div id="actionMenu" class="dropdown-menu hidden">
-          <button type="button" data-value="Check-Out">Check-Out</button>
-          <button type="button" data-value="Check-In">Check-In</button>
+        <button type="button" id="actionBtn" class="btn-inline" aria-haspopup="true" aria-expanded="false" aria-controls="actionMenu">Select Action</button>
+        <div id="actionMenu" class="dropdown-menu hidden" role="menu">
+          <button type="button" data-value="Check-Out" role="menuitem">Check-Out</button>
+          <button type="button" data-value="Check-In" role="menuitem">Check-In</button>
         </div>
       </div>
       <input type="hidden" id="action">
@@ -115,12 +115,12 @@
     <hr>
     <div class="mb-15">
       <div class="dropdown">
-        <button type="button" class="btn-inline" id="importExportBtn">Import/Export</button>
-        <div id="importExportMenu" class="dropdown-menu hidden">
-          <button type="button" id="exportEmployeesAction">Export Employees to CSV</button>
-          <button type="button" id="importEmployeesAction">Import Employees CSV</button>
-          <button type="button" id="exportEquipmentAction">Export Equipment to CSV</button>
-          <button type="button" id="importEquipmentAction">Import Equipment CSV</button>
+        <button type="button" class="btn-inline" id="importExportBtn" aria-haspopup="true" aria-expanded="false" aria-controls="importExportMenu">Import/Export</button>
+        <div id="importExportMenu" class="dropdown-menu hidden" role="menu">
+          <button type="button" id="exportEmployeesAction" role="menuitem">Export Employees to CSV</button>
+          <button type="button" id="importEmployeesAction" role="menuitem">Import Employees CSV</button>
+          <button type="button" id="exportEquipmentAction" role="menuitem">Export Equipment to CSV</button>
+          <button type="button" id="importEquipmentAction" role="menuitem">Import Equipment CSV</button>
         </div>
       </div>
       <input type="file" id="importEmployeesFile" accept=".csv" class="hidden">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -724,42 +724,104 @@ document.getElementById('addEquipmentAdminBtn').addEventListener('click', addEqu
   }
 });
 
+function setupDropdown(button, menu, onSelect) {
+  const items = Array.from(menu.querySelectorAll('button'));
+
+  const openMenu = () => {
+    menu.classList.remove('hidden');
+    button.setAttribute('aria-expanded', 'true');
+    items[0]?.focus();
+  };
+
+  const closeMenu = () => {
+    menu.classList.add('hidden');
+    button.setAttribute('aria-expanded', 'false');
+    button.focus();
+  };
+
+  const toggleMenu = () => {
+    if (menu.classList.contains('hidden')) {
+      openMenu();
+    } else {
+      closeMenu();
+    }
+  };
+
+  button.addEventListener('click', toggleMenu);
+  button.addEventListener('keydown', (e) => {
+    if (['Enter', ' '].includes(e.key)) {
+      e.preventDefault();
+      toggleMenu();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      openMenu();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      openMenu();
+      items[items.length - 1]?.focus();
+    } else if (e.key === 'Escape') {
+      if (button.getAttribute('aria-expanded') === 'true') {
+        e.preventDefault();
+        closeMenu();
+      }
+    }
+  });
+
+  items.forEach((item, index) => {
+    item.setAttribute('tabindex', '-1');
+    item.addEventListener('click', () => {
+      onSelect?.(item);
+      closeMenu();
+    });
+    item.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        items[(index + 1) % items.length].focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        items[(index - 1 + items.length) % items.length].focus();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        closeMenu();
+      }
+    });
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!menu.contains(e.target) && e.target !== button) {
+      if (button.getAttribute('aria-expanded') === 'true') {
+        closeMenu();
+      }
+    }
+  });
+}
+
 const actionBtn = document.getElementById('actionBtn');
 const actionMenu = document.getElementById('actionMenu');
 if (actionBtn && actionMenu) {
-  actionBtn.addEventListener('click', () => {
-    actionMenu.classList.toggle('hidden');
-  });
-  actionMenu.querySelectorAll('button').forEach(btn => {
-    btn.addEventListener('click', () => {
-      document.getElementById('action').value = btn.dataset.value || btn.textContent;
-      actionBtn.textContent = btn.textContent;
-      actionMenu.classList.add('hidden');
-    });
+  setupDropdown(actionBtn, actionMenu, (item) => {
+    document.getElementById('action').value = item.dataset.value || item.textContent;
+    actionBtn.textContent = item.textContent;
   });
 }
 
 const importExportBtn = document.getElementById('importExportBtn');
 const importExportMenu = document.getElementById('importExportMenu');
-importExportBtn.addEventListener('click', () => {
-  importExportMenu.classList.toggle('hidden');
-});
+if (importExportBtn && importExportMenu) {
+  setupDropdown(importExportBtn, importExportMenu);
+}
 
 document.getElementById('exportEmployeesAction').addEventListener('click', () => {
   exportEmployeesCSV();
-  importExportMenu.classList.add('hidden');
 });
 document.getElementById('importEmployeesAction').addEventListener('click', () => {
   triggerImportEmployees();
-  importExportMenu.classList.add('hidden');
 });
 document.getElementById('exportEquipmentAction').addEventListener('click', () => {
   exportEquipmentCSV();
-  importExportMenu.classList.add('hidden');
 });
 document.getElementById('importEquipmentAction').addEventListener('click', () => {
   triggerImportEquipment();
-  importExportMenu.classList.add('hidden');
 });
 document.getElementById('importEmployeesFile').addEventListener('change', handleImportEmployees);
 document.getElementById('importEquipmentFile').addEventListener('change', handleImportEquipment);


### PR DESCRIPTION
## Summary
- Enhance dropdown buttons with `aria-haspopup`, `aria-expanded`, and menu roles in HTML
- Implement reusable `setupDropdown` helper handling Enter, Space, Escape, and arrow keys for menu accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4f57e264832bbe1d70bd093f2867