### PR TITLE
Use delegated nav handler to collapse menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,9 @@
   <!-- Navigation -->
   <button id="navToggle" class="nav-toggle" aria-expanded="false" aria-controls="mainNav">Menu</button>
   <nav id="mainNav">
-    <a href="#" id="navCheckout">Check-Out</a>
-    <a href="#" id="navAdmin">Admin</a>
-    <a href="#" id="navRecords">Records</a>
+    <a href="#" id="navCheckout" data-section="checkout">Check-Out</a>
+    <a href="#" id="navAdmin" data-section="admin">Admin</a>
+    <a href="#" id="navRecords" data-section="records">Records</a>
   </nav>
 
   <!-- Check-Out Section -->

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -674,28 +674,18 @@ function handleImportEquipment(event) {
 
 /* ---------- Event Listeners ---------- */
 
-document.getElementById('navCheckout').addEventListener('click', (e) => {
-  e.preventDefault();
-  showSection('checkout');
-  nav.classList.remove('show');
-  navToggle.setAttribute('aria-expanded', 'false');
-});
-document.getElementById('navAdmin').addEventListener('click', (e) => {
-  e.preventDefault();
-  showSection('admin');
-  nav.classList.remove('show');
-  navToggle.setAttribute('aria-expanded', 'false');
-});
-document.getElementById('navRecords').addEventListener('click', (e) => {
-  e.preventDefault();
-  showSection('records');
-  nav.classList.remove('show');
-  navToggle.setAttribute('aria-expanded', 'false');
-});
-
 const navToggle = document.getElementById('navToggle');
 const nav = document.getElementById('mainNav');
 if (navToggle && nav) {
+  nav.addEventListener('click', (e) => {
+    const link = e.target.closest('a[data-section]');
+    if (!link) return;
+    e.preventDefault();
+    showSection(link.dataset.section);
+    nav.classList.remove('show');
+    navToggle.setAttribute('aria-expanded', 'false');
+  });
+
   navToggle.addEventListener('click', () => {
     const expanded = navToggle.getAttribute('aria-expanded') === 'true';
     navToggle.setAttribute('aria-expanded', String(!expanded));


### PR DESCRIPTION
## Summary
- Delegate nav link clicks to the nav container
- Collapse menu and reset aria-expanded when a section link is selected
- Add data-section attributes to navigation links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e50c1bf4c832b96176db6719cc0c0