### PR TITLE
Show placeholder when admin lists are empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
     <label for="employeeSearch" class="sr-only">Search employees</label>
     <input type="text" id="employeeSearch" placeholder="Search employees">
     <div class="list-container">
-      <ul id="employeeList"></ul>
+      <ul id="employeeList"><li class="placeholder">No employees added yet.</li></ul>
     </div>
     <button type="button" id="employeePrev">Prev</button>
     <button type="button" id="employeeNext">Next</button>
@@ -106,7 +106,7 @@
     <label for="equipmentSearch" class="sr-only">Search equipment</label>
     <input type="text" id="equipmentSearch" placeholder="Search equipment">
     <div class="list-container">
-      <ul id="equipmentListAdmin"></ul>
+      <ul id="equipmentListAdmin"><li class="placeholder">No equipment added yet.</li></ul>
     </div>
     <button type="button" id="equipmentPrev">Prev</button>
     <button type="button" id="equipmentNext">Next</button>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -319,19 +319,27 @@ function displayEmployeeList(page = employeePage, filter = employeeFilter) {
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   page = Math.min(Math.max(page, 0), totalPages - 1);
   const start = page * pageSize;
-  filtered.slice(start, start + pageSize).forEach(([badge, name]) => {
-    const li = document.createElement('li');
-    const textSpan = document.createElement('span');
-    textSpan.textContent = `${badge}: ${name}`;
-    const del = document.createElement('span');
-    del.className = 'deleteEmployee';
-    del.textContent = '❌';
-    del.title = 'Remove Employee';
-    del.addEventListener('click', () => removeEmployee(badge));
-    li.appendChild(textSpan);
-    li.appendChild(del);
-    list.appendChild(li);
-  });
+  const pageItems = filtered.slice(start, start + pageSize);
+  if (pageItems.length === 0) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'placeholder';
+    placeholder.textContent = 'No employees added yet.';
+    list.appendChild(placeholder);
+  } else {
+    pageItems.forEach(([badge, name]) => {
+      const li = document.createElement('li');
+      const textSpan = document.createElement('span');
+      textSpan.textContent = `${badge}: ${name}`;
+      const del = document.createElement('span');
+      del.className = 'deleteEmployee';
+      del.textContent = '❌';
+      del.title = 'Remove Employee';
+      del.addEventListener('click', () => removeEmployee(badge));
+      li.appendChild(textSpan);
+      li.appendChild(del);
+      list.appendChild(li);
+    });
+  }
   employeePage = page;
   employeeFilter = filter;
   const prevBtn = document.getElementById('employeePrev');
@@ -390,19 +398,27 @@ function displayEquipmentListAdmin(page = equipmentPage, filter = equipmentFilte
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   page = Math.min(Math.max(page, 0), totalPages - 1);
   const start = page * pageSize;
-  filtered.slice(start, start + pageSize).forEach(([serial, name]) => {
-    const li = document.createElement('li');
-    const textSpan = document.createElement('span');
-    textSpan.textContent = `${serial}: ${name}`;
-    const del = document.createElement('span');
-    del.className = 'deleteEquipment';
-    del.textContent = '❌';
-    del.title = 'Remove Equipment';
-    del.addEventListener('click', () => removeEquipmentAdmin(serial));
-    li.appendChild(textSpan);
-    li.appendChild(del);
-    list.appendChild(li);
-  });
+  const pageItems = filtered.slice(start, start + pageSize);
+  if (pageItems.length === 0) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'placeholder';
+    placeholder.textContent = 'No equipment added yet.';
+    list.appendChild(placeholder);
+  } else {
+    pageItems.forEach(([serial, name]) => {
+      const li = document.createElement('li');
+      const textSpan = document.createElement('span');
+      textSpan.textContent = `${serial}: ${name}`;
+      const del = document.createElement('span');
+      del.className = 'deleteEquipment';
+      del.textContent = '❌';
+      del.title = 'Remove Equipment';
+      del.addEventListener('click', () => removeEquipmentAdmin(serial));
+      li.appendChild(textSpan);
+      li.appendChild(del);
+      list.appendChild(li);
+    });
+  }
   equipmentPage = page;
   equipmentFilter = filter;
   const prevBtn = document.getElementById('equipmentPrev');


### PR DESCRIPTION
## Summary
- Display a placeholder message in the employee and equipment admin lists when no items exist
- Clear placeholders once entries are added and restore them when lists are emptied

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e559540a0832bae51f9a6192ead68