### PR TITLE
Focus badge after checkout

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -305,6 +305,7 @@ document.getElementById('checkoutForm').addEventListener('submit', function(e) {
   const equipmentList = document.getElementById('equipmentList');
   equipmentList.innerHTML = "";
   addEquipmentField();
+  document.getElementById('badge').focus();
 });
 
 /* ---------- Admin Panel Functions ---------- */


### PR DESCRIPTION
## Summary
- After form submission, reset and add equipment field then refocus badge input for faster next entry.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e576a8240832bbeadc50803839fca