### PR TITLE
Hide dropdowns on outside clicks

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -826,6 +826,21 @@ if (importExportBtn && importExportMenu) {
   setupDropdown(importExportBtn, importExportMenu);
 }
 
+document.addEventListener('click', (e) => {
+  const clickedInsideDropdown =
+    actionMenu?.contains(e.target) ||
+    actionBtn?.contains(e.target) ||
+    importExportMenu?.contains(e.target) ||
+    importExportBtn?.contains(e.target);
+
+  if (!clickedInsideDropdown) {
+    actionMenu?.classList.add('hidden');
+    actionBtn?.setAttribute('aria-expanded', 'false');
+    importExportMenu?.classList.add('hidden');
+    importExportBtn?.setAttribute('aria-expanded', 'false');
+  }
+});
+
 document.getElementById('exportEmployeesAction').addEventListener('click', () => {
   exportEmployeesCSV();
 });


### PR DESCRIPTION
## Summary
- Close action and import/export dropdowns when clicking outside of them using a global listener

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e5a0a7848832b886ee8d9b2e268b2