### PR TITLE
Use icons and page indicators for admin pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <link rel="icon" type="image/png" href="images/image.png">
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="styles/main.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FedEx Equipment Check-Out System</title>
 </head>
@@ -85,8 +86,11 @@
     <div class="list-container">
       <ul id="employeeList"><li class="placeholder">No employees added yet.</li></ul>
     </div>
-    <button type="button" id="employeePrev">Prev</button>
-    <button type="button" id="employeeNext">Next</button>
+    <div class="pagination-controls">
+      <button type="button" id="employeePrev" class="btn-inline material-icons hidden" aria-label="Previous page">chevron_left</button>
+      <span id="employeePageIndicator" class="page-indicator"></span>
+      <button type="button" id="employeeNext" class="btn-inline material-icons" aria-label="Next page">chevron_right</button>
+    </div>
     <hr>
     <h2>Manage Equipment</h2>
     <form id="equipmentAdminForm">
@@ -108,9 +112,12 @@
     <div class="list-container">
       <ul id="equipmentListAdmin"><li class="placeholder">No equipment added yet.</li></ul>
     </div>
-    <button type="button" id="equipmentPrev">Prev</button>
-    <button type="button" id="equipmentNext">Next</button>
-    
+    <div class="pagination-controls">
+      <button type="button" id="equipmentPrev" class="btn-inline material-icons hidden" aria-label="Previous page">chevron_left</button>
+      <span id="equipmentPageIndicator" class="page-indicator"></span>
+      <button type="button" id="equipmentNext" class="btn-inline material-icons" aria-label="Next page">chevron_right</button>
+    </div>
+
     <!-- New Import/Export Section -->
     <hr>
     <div class="mb-15">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -345,8 +345,10 @@ function displayEmployeeList(page = employeePage, filter = employeeFilter) {
   employeeFilter = filter;
   const prevBtn = document.getElementById('employeePrev');
   const nextBtn = document.getElementById('employeeNext');
-  if (prevBtn) prevBtn.disabled = page <= 0;
+  const pageIndicator = document.getElementById('employeePageIndicator');
+  if (prevBtn) prevBtn.classList.toggle('hidden', page <= 0);
   if (nextBtn) nextBtn.disabled = page >= totalPages - 1;
+  if (pageIndicator) pageIndicator.textContent = `Page ${page + 1} of ${totalPages}`;
 }
 function addEmployee() {
   const nameInput = document.getElementById('empName');
@@ -428,8 +430,10 @@ function displayEquipmentListAdmin(page = equipmentPage, filter = equipmentFilte
   equipmentFilter = filter;
   const prevBtn = document.getElementById('equipmentPrev');
   const nextBtn = document.getElementById('equipmentNext');
-  if (prevBtn) prevBtn.disabled = page <= 0;
+  const pageIndicator = document.getElementById('equipmentPageIndicator');
+  if (prevBtn) prevBtn.classList.toggle('hidden', page <= 0);
   if (nextBtn) nextBtn.disabled = page >= totalPages - 1;
+  if (pageIndicator) pageIndicator.textContent = `Page ${page + 1} of ${totalPages}`;
 }
 function addEquipmentAdmin() {
   const nameInput = document.getElementById('equipName');

--- a/styles/main.css
+++ b/styles/main.css
@@ -207,6 +207,16 @@
     .admin form div {
       margin-bottom: 0.625rem;
     }
+    .pagination-controls {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 0.5rem;
+      margin: 0.625rem 0;
+    }
+    .page-indicator {
+      font-size: 0.875rem;
+    }
 
     /* Records Section */
     #records {


### PR DESCRIPTION
## Summary
- replace admin pagination buttons with Material Icons
- show current page and hide previous control on the first page
- add styles and Material Icons stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e82cea258832b9888fa061b566a9b