### PR TITLE
Use flex gap for nav icon spacing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -180,7 +180,6 @@
 
     .nav-icon {
       font-size: 1.2rem;
-      margin-right: 0.25rem;
     }
 
     /* Check-Out Section */


### PR DESCRIPTION
## Summary
- Remove `margin-right` from `.nav-icon` and rely on flex gap for consistent spacing across navigation items.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f66550170832bb770ec1c79567fb6