### PR TITLE
Switch to Material Symbols icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <link rel="icon" type="image/png" href="images/image.png">
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="styles/main.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FedEx Equipment Check-Out System</title>
 </head>
@@ -22,11 +22,11 @@
   <div id="notifications" role="alert" aria-live="polite"></div>
 
   <!-- Navigation -->
-  <button id="navToggle" class="nav-toggle" aria-expanded="false" aria-controls="mainNav"><span class="material-icons nav-icon">menu</span> Menu</button>
+  <button id="navToggle" class="nav-toggle" aria-expanded="false" aria-controls="mainNav"><span class="material-symbols-outlined nav-icon">menu</span> Menu</button>
   <nav id="mainNav">
-    <a href="#" id="navCheckout" data-section="checkout"><span class="material-icons nav-icon">barcode_reader</span>Check-Out</a>
-    <a href="#" id="navAdmin" data-section="admin"><span class="material-icons nav-icon">admin_panel_settings</span>Admin</a>
-    <a href="#" id="navRecords" data-section="records"><span class="material-icons nav-icon">data table</span>Records</a>
+    <a href="#" id="navCheckout" data-section="checkout"><span class="material-symbols-outlined nav-icon">barcode_reader</span>Check-Out</a>
+    <a href="#" id="navAdmin" data-section="admin"><span class="material-symbols-outlined nav-icon">admin_panel_settings</span>Admin</a>
+    <a href="#" id="navRecords" data-section="records"><span class="material-symbols-outlined nav-icon">data_table</span>Records</a>
   </nav>
 
   <!-- Check-Out Section -->
@@ -87,9 +87,9 @@
       <ul id="employeeList"><li class="placeholder">No employees added yet.</li></ul>
     </div>
     <div class="pagination-controls">
-      <button type="button" id="employeePrev" class="btn-inline material-icons hidden" aria-label="Previous page">chevron_left</button>
+      <button type="button" id="employeePrev" class="btn-inline material-symbols-outlined hidden" aria-label="Previous page">chevron_left</button>
       <span id="employeePageIndicator" class="page-indicator"></span>
-      <button type="button" id="employeeNext" class="btn-inline material-icons" aria-label="Next page">chevron_right</button>
+      <button type="button" id="employeeNext" class="btn-inline material-symbols-outlined" aria-label="Next page">chevron_right</button>
     </div>
     <hr>
     <h2>Manage Equipment</h2>
@@ -113,9 +113,9 @@
       <ul id="equipmentListAdmin"><li class="placeholder">No equipment added yet.</li></ul>
     </div>
     <div class="pagination-controls">
-      <button type="button" id="equipmentPrev" class="btn-inline material-icons hidden" aria-label="Previous page">chevron_left</button>
+      <button type="button" id="equipmentPrev" class="btn-inline material-symbols-outlined hidden" aria-label="Previous page">chevron_left</button>
       <span id="equipmentPageIndicator" class="page-indicator"></span>
-      <button type="button" id="equipmentNext" class="btn-inline material-icons" aria-label="Next page">chevron_right</button>
+      <button type="button" id="equipmentNext" class="btn-inline material-symbols-outlined" aria-label="Next page">chevron_right</button>
     </div>
 
     <!-- New Import/Export Section -->


### PR DESCRIPTION
## Summary
- replace Material Icons with Material Symbols Outlined font
- update all icon elements to use `material-symbols-outlined` and rename Records icon to `data_table`

## Testing
- `node -e "const fs=require('fs');const {JSDOM}=require('jsdom');const html=fs.readFileSync('index.html','utf8');const dom=new JSDOM(html);const document=dom.window.document;const link=document.querySelector('link[href*=\"Material+Symbols+Outlined\"]');const icons=[...document.querySelectorAll('.material-symbols-outlined')].map(el=>el.textContent.trim());console.log('link present:', !!link);console.log('icons:', icons);"`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f749480ac832bbd385dffb629d73a