### PR TITLE
Allow nav links to flex on small screens

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -300,11 +300,17 @@
       }
 
       nav a {
-        flex: 0 0 8rem;
+        flex: 1 1 auto;
+        width: 100%;
+        padding: 0.375rem 0.75rem;
       }
 
       .nav-toggle {
         display: flex;
+      }
+
+      .nav-icon {
+        font-size: 1rem;
       }
 
       .employeeRow,


### PR DESCRIPTION
## Summary
- Let nav links expand and shrink under the 37.5rem breakpoint by using `flex: 1 1 auto` and full width
- Reduce link padding and adjust `.nav-icon` font size for better fit on compact screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9fc063b4832ba2c9c9b98c0ee01b