### PR TITLE
feat: make full-width buttons opt-in

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
         </div>
       </div>
       <input type="hidden" id="action">
-      <button type="submit" class="btn-primary">Submit</button>
+      <button type="submit" class="btn-primary btn-block">Submit</button>
     </form>
   </section>
 
@@ -78,7 +78,7 @@
         <input type="text" id="empBadge" placeholder="Enter Badge ID" required>
         <span class="error-message" aria-live="polite"></span>
       </div>
-      <button type="button" id="addEmployeeBtn" class="btn-primary">Add Employee</button>
+      <button type="button" id="addEmployeeBtn" class="btn-primary btn-block">Add Employee</button>
     </form>
     <h3>Current Employees</h3>
     <label for="employeeSearch" class="sr-only">Search employees</label>
@@ -104,7 +104,7 @@
         <input type="text" id="equipSerial" placeholder="Enter Equipment Serial" required>
         <span class="error-message" aria-live="polite"></span>
       </div>
-      <button type="button" id="addEquipmentAdminBtn" class="btn-primary">Add Equipment</button>
+      <button type="button" id="addEquipmentAdminBtn" class="btn-primary btn-block">Add Equipment</button>
     </form>
     <h3>Current Equipment</h3>
     <label for="equipmentSearch" class="sr-only">Search equipment</label>

--- a/styles/main.css
+++ b/styles/main.css
@@ -54,6 +54,10 @@
       cursor: pointer;
       transition: background-color 0.3s ease;
       border-radius: 0.5rem;
+    }
+
+    /* Full-width block buttons */
+    .btn-block {
       width: 100%;
     }
     .btn-primary {
@@ -74,7 +78,7 @@
     .btn-danger:hover {
       background-color: #990000;
     }
-    /* Inline buttons override full width */
+    /* Inline buttons maintain natural width */
     .btn-inline {
       width: auto;
       display: inline-block;


### PR DESCRIPTION
## Summary
- remove global 100% width from `button`
- add `.btn-block` utility class for full-width buttons
- use `.btn-block` on checkout and admin form submission buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fafa79174832b88875cb4587ffc62