### PR TITLE
Add ARIA validation attributes to form fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,16 +35,16 @@
     <form id="checkoutForm">
       <label for="badge">Employee Badge ID:</label>
       <div class="employeeRow">
-        <input type="text" id="badge" placeholder="Enter Employee Badge ID" required autofocus>
-        <span class="error-message" aria-live="polite"></span>
+        <input type="text" id="badge" placeholder="Enter Employee Badge ID" required autofocus aria-describedby="badgeError">
+        <span id="badgeError" class="error-message" aria-live="polite"></span>
         <span id="employeeName"></span>
       </div>
       <label for="equipment">Equipment Barcodes:</label>
       <div id="equipmentList">
         <div class="equipment-item">
           <div class="equipmentRow">
-            <input type="text" id="equipment0" name="equipment" placeholder="Enter Equipment Barcode" required>
-            <span class="error-message" aria-live="polite"></span>
+            <input type="text" id="equipment0" name="equipment" placeholder="Enter Equipment Barcode" required aria-describedby="equipment0Error">
+            <span id="equipment0Error" class="error-message" aria-live="polite"></span>
             <span class="equipmentNameDisplay"></span>
           </div>
           <button type="button" class="removeEquipment hidden btn-danger">Remove</button>
@@ -70,13 +70,13 @@
     <form id="adminForm">
       <div>
         <label for="empName">Employee Name:</label>
-        <input type="text" id="empName" placeholder="Enter Employee Name" required>
-        <span class="error-message" aria-live="polite"></span>
+        <input type="text" id="empName" placeholder="Enter Employee Name" required aria-describedby="empNameError">
+        <span id="empNameError" class="error-message" aria-live="polite"></span>
       </div>
       <div>
         <label for="empBadge">Employee Badge ID:</label>
-        <input type="text" id="empBadge" placeholder="Enter Badge ID" required>
-        <span class="error-message" aria-live="polite"></span>
+        <input type="text" id="empBadge" placeholder="Enter Badge ID" required aria-describedby="empBadgeError">
+        <span id="empBadgeError" class="error-message" aria-live="polite"></span>
       </div>
       <button type="button" id="addEmployeeBtn" class="btn-primary btn-block">Add Employee</button>
     </form>
@@ -96,13 +96,13 @@
     <form id="equipmentAdminForm">
       <div>
         <label for="equipName">Equipment Name:</label>
-        <input type="text" id="equipName" placeholder="Enter Equipment Name" required>
-        <span class="error-message" aria-live="polite"></span>
+        <input type="text" id="equipName" placeholder="Enter Equipment Name" required aria-describedby="equipNameError">
+        <span id="equipNameError" class="error-message" aria-live="polite"></span>
       </div>
       <div>
         <label for="equipSerial">Equipment Serial Number:</label>
-        <input type="text" id="equipSerial" placeholder="Enter Equipment Serial" required>
-        <span class="error-message" aria-live="polite"></span>
+        <input type="text" id="equipSerial" placeholder="Enter Equipment Serial" required aria-describedby="equipSerialError">
+        <span id="equipSerialError" class="error-message" aria-live="polite"></span>
       </div>
       <button type="button" id="addEquipmentAdminBtn" class="btn-primary btn-block">Add Equipment</button>
     </form>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -71,6 +71,7 @@ function setFieldError(input, message) {
     errorSpan.textContent = message;
   }
   input.classList.add('error');
+  input.setAttribute('aria-invalid', 'true');
 }
 
 function clearFieldError(input) {
@@ -79,6 +80,7 @@ function clearFieldError(input) {
     errorSpan.textContent = '';
   }
   input.classList.remove('error');
+  input.removeAttribute('aria-invalid');
 }
 
 function updateNotifications() {
@@ -158,6 +160,8 @@ function addEquipmentField() {
   const errorSpan = document.createElement('span');
   errorSpan.className = 'error-message';
   errorSpan.setAttribute('aria-live', 'polite');
+  errorSpan.id = `${input.id}Error`;
+  input.setAttribute('aria-describedby', errorSpan.id);
 
   const nameSpan = document.createElement('span');
   nameSpan.className = 'equipmentNameDisplay';


### PR DESCRIPTION
## Summary
- mark invalid fields with `aria-invalid` and clear on reset
- link inputs to error messages with `aria-describedby`
- generate unique `aria-describedby` ids for dynamically added equipment fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb2a26794832bac3d19fea2943b63