### PR TITLE
Replace deletion spans with accessible buttons

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -335,10 +335,12 @@ function displayEmployeeList(page = employeePage, filter = employeeFilter) {
       const li = document.createElement('li');
       const textSpan = document.createElement('span');
       textSpan.textContent = `${badge}: ${name}`;
-      const del = document.createElement('span');
+      const del = document.createElement('button');
+      del.type = 'button';
       del.className = 'deleteEmployee';
       del.textContent = '❌';
       del.title = 'Remove Employee';
+      del.setAttribute('aria-label', 'Remove Employee');
       del.addEventListener('click', () => removeEmployee(badge));
       li.appendChild(textSpan);
       li.appendChild(del);
@@ -420,10 +422,12 @@ function displayEquipmentListAdmin(page = equipmentPage, filter = equipmentFilte
       const li = document.createElement('li');
       const textSpan = document.createElement('span');
       textSpan.textContent = `${serial}: ${name}`;
-      const del = document.createElement('span');
+      const del = document.createElement('button');
+      del.type = 'button';
       del.className = 'deleteEquipment';
       del.textContent = '❌';
       del.title = 'Remove Equipment';
+      del.setAttribute('aria-label', 'Remove Equipment');
       del.addEventListener('click', () => removeEquipmentAdmin(serial));
       li.appendChild(textSpan);
       li.appendChild(del);

--- a/styles/main.css
+++ b/styles/main.css
@@ -371,5 +371,8 @@
   margin-left: 0.5rem;
   cursor: pointer;
   color: red;
+  background: none;
+  border: none;
+  padding: 0;
 }
 


### PR DESCRIPTION
## Summary
- replace `<span>` delete controls with `<button>` elements in employee and equipment admin lists
- add `aria-label` attributes for accessibility
- update CSS selectors to style new delete buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb82e06d0832bb1502ee06ffd9d04