### PR TITLE
Handle admin actions via submit events

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
         <input type="text" id="empBadge" placeholder="Enter Badge ID" required aria-describedby="empBadgeError">
         <span id="empBadgeError" class="error-message" aria-live="polite"></span>
       </div>
-      <button type="button" id="addEmployeeBtn" class="btn-primary btn-block">Add Employee</button>
+      <button type="submit" id="addEmployeeBtn" class="btn-primary btn-block">Add Employee</button>
     </form>
     <h3>Current Employees</h3>
     <label for="employeeSearch" class="sr-only">Search employees</label>
@@ -104,7 +104,7 @@
         <input type="text" id="equipSerial" placeholder="Enter Equipment Serial" required aria-describedby="equipSerialError">
         <span id="equipSerialError" class="error-message" aria-live="polite"></span>
       </div>
-      <button type="button" id="addEquipmentAdminBtn" class="btn-primary btn-block">Add Equipment</button>
+      <button type="submit" id="addEquipmentAdminBtn" class="btn-primary btn-block">Add Equipment</button>
     </form>
     <h3>Current Equipment</h3>
     <label for="equipmentSearch" class="sr-only">Search equipment</label>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -757,8 +757,16 @@ if (initialEquipmentInput) {
 }
 
 document.getElementById('addEquipmentBtn').addEventListener('click', addEquipmentField);
-document.getElementById('addEmployeeBtn').addEventListener('click', addEmployee);
-document.getElementById('addEquipmentAdminBtn').addEventListener('click', addEquipmentAdmin);
+
+document.getElementById('adminForm').addEventListener('submit', (e) => {
+  e.preventDefault();
+  addEmployee();
+});
+
+document.getElementById('equipmentAdminForm').addEventListener('submit', (e) => {
+  e.preventDefault();
+  addEquipmentAdmin();
+});
 
 ['empName','empBadge','equipName','equipSerial'].forEach(id => {
   const el = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Change admin "Add Employee" and "Add Equipment" buttons to submit type
- Hook admin forms' submit events to add employees and equipment with default prevention

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff2fc3d14832bae223f6177cc81d4