### PR TITLE
Position mobile menu top-left without shifting layout

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -315,6 +315,16 @@
       nav {
         flex-direction: column;
         display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        width: 100%;
+        margin: 0;
+        padding-top: 3rem;
+        background-color: #fff;
+        z-index: 1000;
+        box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,0.1);
       }
 
       nav.show {
@@ -329,6 +339,10 @@
 
       .nav-toggle {
         display: flex;
+        position: fixed;
+        top: 0.5rem;
+        left: 0.5rem;
+        z-index: 1001;
       }
 
       .nav-icon {


### PR DESCRIPTION
## Summary
- Position mobile navigation toggle in the top-left corner on small screens
- Overlay navigation menu above content so it no longer shifts the page

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - no access to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a06c25b620832b900db43f16170172