### PR TITLE
feat: style nav toggle when menu expanded

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -760,12 +760,14 @@ if (navToggle && nav) {
     showSection(link.dataset.section);
     nav.classList.remove('show');
     navToggle.setAttribute('aria-expanded', 'false');
+    navToggle.classList.remove('open');
   });
 
   navToggle.addEventListener('click', () => {
     const expanded = navToggle.getAttribute('aria-expanded') === 'true';
     navToggle.setAttribute('aria-expanded', String(!expanded));
-    nav.classList.toggle('show');
+    nav.classList.toggle('show', !expanded);
+    navToggle.classList.toggle('open', !expanded);
   });
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -322,6 +322,7 @@
         width: 100%;
         margin: 0;
         padding-top: 3rem;
+        padding-right: 3rem;
         background-color: #fff;
         z-index: 1000;
         box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,0.1);
@@ -343,6 +344,11 @@
         top: 0.5rem;
         left: 0.5rem;
         z-index: 1001;
+      }
+
+      .nav-toggle.open {
+        left: auto;
+        right: 0.5rem;
       }
 
       .nav-icon {

--- a/tests/navCollapse.test.js
+++ b/tests/navCollapse.test.js
@@ -35,3 +35,20 @@ test('nav collapses when link clicked', () => {
   expect(nav.classList.contains('show')).toBe(false);
   expect(navToggle.getAttribute('aria-expanded')).toBe('false');
 });
+
+test('nav toggle open class reflects menu state', () => {
+  const win = setupDom();
+  const nav = win.document.getElementById('mainNav');
+  const navToggle = win.document.getElementById('navToggle');
+
+  expect(nav.classList.contains('show')).toBe(false);
+  expect(navToggle.classList.contains('open')).toBe(false);
+
+  navToggle.click();
+  expect(nav.classList.contains('show')).toBe(true);
+  expect(navToggle.classList.contains('open')).toBe(true);
+
+  navToggle.click();
+  expect(nav.classList.contains('show')).toBe(false);
+  expect(navToggle.classList.contains('open')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- toggle `open` class on nav button to reflect menu state
- reposition nav toggle in mobile view and add padding to avoid covering links
- test nav toggle open class toggles correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a071cacfec832b850a8fb2ca03292e