### PR TITLE
feat: add mobile nav overlay

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -320,12 +320,14 @@
         left: 0;
         right: 0;
         width: 100%;
+        height: 100vh;
+        overflow-y: auto;
         margin: 0;
         padding-top: 3rem;
         padding-right: 3rem;
         background-color: #fff;
         z-index: 1000;
-        box-shadow: 0 0.125rem 0.25rem rgba(0,0,0,0.1);
+        box-shadow: 0 0 1rem rgba(0,0,0,0.2);
       }
 
       nav.show {

--- a/tests/navCollapse.test.js
+++ b/tests/navCollapse.test.js
@@ -4,10 +4,12 @@ const { JSDOM } = require('jsdom');
 
 const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
 const script = fs.readFileSync(path.resolve(__dirname, '../scripts/app.js'), 'utf8');
+const css = fs.readFileSync(path.resolve(__dirname, '../styles/main.css'), 'utf8');
 
 function setupDom() {
   const dom = new JSDOM(html, { url: 'http://localhost', runScripts: 'dangerously' });
   const { window } = dom;
+  window.document.head.insertAdjacentHTML('beforeend', `<style>${css}</style>`);
   global.window = window;
   global.document = window.document;
   global.localStorage = window.localStorage;
@@ -51,4 +53,24 @@ test('nav toggle open class reflects menu state', () => {
   navToggle.click();
   expect(nav.classList.contains('show')).toBe(false);
   expect(navToggle.classList.contains('open')).toBe(false);
+});
+
+test('nav overlay styles applied when menu opened', () => {
+  const win = setupDom();
+  const navToggle = win.document.getElementById('navToggle');
+  navToggle.click();
+  const nav = win.document.getElementById('mainNav');
+  expect(nav.classList.contains('show')).toBe(true);
+
+  const sheet = win.document.styleSheets[0];
+  const mediaRule = Array.from(sheet.cssRules).find(
+    r => r.type === win.CSSRule.MEDIA_RULE && r.media.mediaText === '(max-width: 37.5rem)'
+  );
+  const navRule = Array.from(mediaRule.cssRules).find(r => r.selectorText === 'nav');
+  const ruleStyle = navRule.style;
+
+  expect(ruleStyle.getPropertyValue('height')).toBe('100vh');
+  expect(ruleStyle.getPropertyValue('overflow-y')).toBe('auto');
+  expect(ruleStyle.getPropertyValue('background-color')).toBe('#fff');
+  expect(ruleStyle.getPropertyValue('box-shadow')).toBe('0 0 1rem rgba(0,0,0,0.2)');
 });


### PR DESCRIPTION
## Summary
- make mobile navigation a full-screen overlay with scroll support and clearer shadow
- test that mobile nav styles include overlay-specific rules when menu opens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a07354962c832bbcfe7f849bac16cd