### PR TITLE
Fix mobile menu persistence

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -769,6 +769,14 @@ if (navToggle && nav) {
     nav.classList.toggle('show', !expanded);
     navToggle.classList.toggle('open', !expanded);
   });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 600) {
+      nav.classList.remove('show');
+      navToggle.setAttribute('aria-expanded', 'false');
+      navToggle.classList.remove('open');
+    }
+  });
 }
 
 document.getElementById('badge').addEventListener('input', lookupEmployee);

--- a/tests/navCollapse.test.js
+++ b/tests/navCollapse.test.js
@@ -74,3 +74,19 @@ test('nav uses white container when menu opened', () => {
   expect(ruleStyle.getPropertyValue('border-radius')).toBe('0.5rem');
   expect(ruleStyle.getPropertyValue('box-shadow')).toBe('0 0 0.625rem rgba(0,0,0,0.1)');
 });
+
+test('nav collapses when viewport enlarges', () => {
+  const win = setupDom();
+  const nav = win.document.getElementById('mainNav');
+  const navToggle = win.document.getElementById('navToggle');
+
+  navToggle.click();
+  expect(nav.classList.contains('show')).toBe(true);
+
+  win.innerWidth = 800;
+  win.dispatchEvent(new win.Event('resize'));
+
+  expect(nav.classList.contains('show')).toBe(false);
+  expect(navToggle.getAttribute('aria-expanded')).toBe('false');
+  expect(navToggle.classList.contains('open')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- close navigation menu when window resizes beyond small screens
- test mobile nav collapses on viewport change

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a07932de0c832b990b6b486eca894b