### PR TITLE
Align mobile nav links with toggle width

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -342,11 +342,12 @@
         box-shadow: 0 0 0.625rem rgba(0,0,0,0.1);
         display: flex;
         flex-direction: column;
+        align-items: flex-start;
       }
 
       nav .nav-container a {
         flex: 1 1 auto;
-        width: 100%;
+        width: auto;
         padding: 0.375rem 0.75rem;
       }
 


### PR DESCRIPTION
## Summary
- Avoid stretched nav links on small screens by letting them size automatically
- Keep mobile nav links from filling container by aligning flex items to the start

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a081653514832b86eac7d8cc217169