### PR TITLE
Add spacing between mobile nav buttons

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -343,6 +343,7 @@
         display: flex;
         flex-direction: column;
         align-items: flex-start;
+        gap: 0.625rem;
       }
 
       nav .nav-container a {


### PR DESCRIPTION
## Summary
- ensure mobile navigation links are separated by a 0.625rem gap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a084cca7c4832bbced0cc3773e3aa0