### PR TITLE
Fix nav toggle staying left when menu opened

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -361,8 +361,7 @@
       }
 
       .nav-toggle.open {
-        left: auto;
-        right: 0.5rem;
+        left: 0.5rem;
       }
 
       .nav-icon {


### PR DESCRIPTION
## Summary
- keep mobile nav toggle fixed to the left when open

## Testing
- `npx jest tests/navCollapse.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a089f58f6c832b876493c5df61e041