### PR TITLE
feat: toggle search input with icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <meta charset="UTF-8" />
   <link rel="stylesheet" href="styles/main.css">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FedEx Equipment Check-Out System</title>
 </head>
@@ -143,8 +144,13 @@
     <div class="records-container">
 
       <form id="recordFilterForm">
-        <label for="recordSearch" class="sr-only">Search by name or badge</label>
-        <input type="text" id="recordSearch" placeholder="Search by name or badge">
+        <div id="recordSearchContainer" class="record-search-container">
+          <button type="button" id="recordSearchToggle" class="search-toggle" aria-label="Search">
+            <i class="bi bi-search"></i>
+          </button>
+          <label for="recordSearch" class="sr-only">Search by name or badge</label>
+          <input type="text" id="recordSearch" class="hidden" placeholder="Search by name or badge">
+        </div>
         <label for="recordEquipment" class="sr-only">Search by equipment name or serial</label>
         <input type="text" id="recordEquipment" placeholder="Search by equipment name or serial">
         <label for="recordDate" class="sr-only">Filter by date</label>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -945,6 +945,20 @@ document.getElementById('equipmentNext').addEventListener('click', () => {
   displayEquipmentListAdmin(equipmentPage + 1);
 });
 
+const recordSearchContainer = document.getElementById('recordSearchContainer');
+const recordSearchInput = document.getElementById('recordSearch');
+const recordSearchToggle = document.getElementById('recordSearchToggle');
+recordSearchToggle.addEventListener('click', () => {
+  recordSearchContainer.classList.toggle('expanded');
+  recordSearchInput.classList.toggle('hidden');
+  if (!recordSearchInput.classList.contains('hidden')) {
+    recordSearchInput.focus();
+  } else {
+    recordSearchInput.value = '';
+    filterRecords();
+  }
+});
+
 document.getElementById('recordFilterForm').addEventListener('submit', (e) => {
   e.preventDefault();
   filterRecords();

--- a/styles/main.css
+++ b/styles/main.css
@@ -270,15 +270,46 @@
       justify-content: center;
       margin-bottom: 0.9375rem;
     }
-    #recordFilterForm input {
-      padding: 0.5rem;
-      flex: 1;
-      min-width: 9.375rem;
-    }
-    #recordFilterForm button {
-      padding: 0.5rem 0.9375rem;
-      border-radius: 0.5rem;
-    }
+#recordFilterForm input {
+  padding: 0.5rem;
+  flex: 1;
+  min-width: 9.375rem;
+}
+#recordFilterForm button {
+  padding: 0.5rem 0.9375rem;
+  border-radius: 0.5rem;
+}
+
+.record-search-container {
+  display: flex;
+  align-items: center;
+}
+
+.record-search-container.expanded {
+  flex: 1;
+}
+
+.search-toggle {
+  background: #fff;
+  border: 0.0625rem solid #ccc;
+  border-radius: 50%;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: #4d148c;
+}
+
+.search-toggle:hover {
+  background-color: #f0f0f0;
+}
+
+.record-search-container input {
+  margin-left: 0.5rem;
+  flex: 1;
+}
     #recordsTable {
       overflow-x: auto;
     }


### PR DESCRIPTION
## Summary
- Show a circular Bootstrap search icon that reveals the record search input when clicked
- Style the new search toggle and container
- Wire up JavaScript to toggle the search field and clear filters when closed

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2447a8ba8832b9ee25efe05c2337d