### PR TITLE
Toggle navigation button icon and text

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   <div id="notifications" role="alert" aria-live="polite"></div>
 
   <!-- Navigation -->
-  <button id="navToggle" class="nav-toggle btn-primary" aria-expanded="false" aria-controls="mainNav"><span class="material-symbols-outlined nav-icon">menu</span> Menu</button>
+  <button id="navToggle" class="nav-toggle btn-primary" aria-expanded="false" aria-controls="mainNav" aria-label="Menu"><span class="material-symbols-outlined nav-icon">menu</span><span class="nav-text">Menu</span></button>
   <nav id="mainNav" aria-hidden="true">
     <ul class="nav-container">
       <li><a href="#" id="navCheckout" data-section="checkout"><span class="material-symbols-outlined nav-icon">barcode_reader</span> Check-Out</a></li>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -752,11 +752,25 @@ function handleImportEquipment(event) {
 
 const navToggle = document.getElementById('navToggle');
 const nav = document.getElementById('mainNav');
+let navToggleIcon;
+let navToggleText;
+if (navToggle) {
+  navToggleIcon = navToggle.querySelector('.nav-icon');
+  navToggleText = navToggle.querySelector('.nav-text');
+}
+
+function updateNavToggle(isOpen) {
+  navToggle.setAttribute('aria-label', isOpen ? 'Close' : 'Menu');
+  if (navToggleIcon) navToggleIcon.textContent = isOpen ? 'close' : 'menu';
+  if (navToggleText) navToggleText.textContent = isOpen ? 'Close' : 'Menu';
+}
+
 function closeNav() {
   nav.classList.remove('show');
   navToggle.setAttribute('aria-expanded', 'false');
   navToggle.classList.remove('open');
   nav.setAttribute('aria-hidden', 'true');
+  updateNavToggle(false);
 }
 
 function openNav() {
@@ -764,6 +778,7 @@ function openNav() {
   navToggle.setAttribute('aria-expanded', 'true');
   navToggle.classList.add('open');
   nav.setAttribute('aria-hidden', 'false');
+  updateNavToggle(true);
   const firstLink = nav.querySelector('a');
   if (firstLink) firstLink.focus();
 }

--- a/tests/navCollapse.test.js
+++ b/tests/navCollapse.test.js
@@ -55,6 +55,29 @@ test('nav toggle open class reflects menu state', () => {
   expect(navToggle.classList.contains('open')).toBe(false);
 });
 
+test('nav toggle updates text, icon, and aria-label', () => {
+  const win = setupDom();
+  const navToggle = win.document.getElementById('navToggle');
+  const icon = navToggle.querySelector('.nav-icon');
+  const label = navToggle.querySelector('.nav-text');
+
+  expect(icon.textContent).toBe('menu');
+  expect(label.textContent.trim()).toBe('Menu');
+  expect(navToggle.getAttribute('aria-label')).toBe('Menu');
+
+  navToggle.click();
+
+  expect(icon.textContent).toBe('close');
+  expect(label.textContent.trim()).toBe('Close');
+  expect(navToggle.getAttribute('aria-label')).toBe('Close');
+
+  navToggle.click();
+
+  expect(icon.textContent).toBe('menu');
+  expect(label.textContent.trim()).toBe('Menu');
+  expect(navToggle.getAttribute('aria-label')).toBe('Menu');
+});
+
 test('nav uses white container when menu opened', () => {
   const win = setupDom();
   win.document.getElementById('navToggle').click();


### PR DESCRIPTION
## Summary
- Toggle nav menu button between "Menu" and "Close" states, updating icon, text, and aria-label.
- Restructure nav toggle markup to expose icon and label elements for dynamic updates.
- Add test covering nav toggle text, icon, and aria-label changes.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab5d185780832bb7e94099fd26917a