### PR TITLE
Disable body scroll when mobile navigation is open

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -770,6 +770,7 @@ function closeNav() {
   navToggle.setAttribute('aria-expanded', 'false');
   navToggle.classList.remove('open');
   nav.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('no-scroll');
   updateNavToggle(false);
 }
 
@@ -778,6 +779,7 @@ function openNav() {
   navToggle.setAttribute('aria-expanded', 'true');
   navToggle.classList.add('open');
   nav.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('no-scroll');
   updateNavToggle(true);
   const firstLink = nav.querySelector('a');
   if (firstLink) firstLink.focus();

--- a/styles/main.css
+++ b/styles/main.css
@@ -89,6 +89,7 @@
       margin: 0.625rem 0;
     }
     .hidden { display: none; }
+    .no-scroll { overflow: hidden; }
     .mb-15 { margin-bottom: 0.9375rem; }
     .dropdown {
       position: relative;

--- a/tests/navCollapse.test.js
+++ b/tests/navCollapse.test.js
@@ -135,3 +135,22 @@ test('nav closes on Escape key', () => {
   expect(nav.classList.contains('show')).toBe(false);
   expect(navToggle.getAttribute('aria-expanded')).toBe('false');
 });
+
+test('body is not scrollable when nav is open', () => {
+  const win = setupDom();
+  const navToggle = win.document.getElementById('navToggle');
+  const body = win.document.body;
+
+  expect(body.classList.contains('no-scroll')).toBe(false);
+  expect(win.getComputedStyle(body).overflow).not.toBe('hidden');
+
+  navToggle.click();
+
+  expect(body.classList.contains('no-scroll')).toBe(true);
+  expect(win.getComputedStyle(body).overflow).toBe('hidden');
+
+  navToggle.click();
+
+  expect(body.classList.contains('no-scroll')).toBe(false);
+  expect(win.getComputedStyle(body).overflow).not.toBe('hidden');
+});


### PR DESCRIPTION
## Summary
- Add `.no-scroll` CSS class to hide overflow when applied
- Toggle `.no-scroll` on `<body>` when opening/closing navigation menu
- Test that page cannot scroll while navigation is visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab60d0ae88832b85f4aead91647ce2