### PR TITLE
Cache loading button HTML for nested content

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -655,13 +655,13 @@ function setLoading(button, loading, text = 'Importing...') {
   if (!button) return;
   if (loading) {
     button.disabled = true;
-    button.dataset.originalText = button.textContent;
+    button.dataset.originalHtml = button.innerHTML;
     button.textContent = text;
   } else {
     button.disabled = false;
-    if (button.dataset.originalText) {
-      button.textContent = button.dataset.originalText;
-      delete button.dataset.originalText;
+    if (button.dataset.originalHtml) {
+      button.innerHTML = button.dataset.originalHtml;
+      delete button.dataset.originalHtml;
     }
   }
 }

--- a/tests/importHandlers.test.js
+++ b/tests/importHandlers.test.js
@@ -118,3 +118,18 @@ test('handleImportEquipment restores button after failure', () => {
   expect(button.textContent).toBe('Import Equipment CSV');
   expect(win.showError).toHaveBeenCalled();
 });
+
+test('setLoading restores nested button HTML', () => {
+  const win = setupDom();
+  const button = win.document.createElement('button');
+  const originalHtml = '<span class="label">Import <strong>Data</strong></span>';
+  button.innerHTML = originalHtml;
+  win.document.body.appendChild(button);
+  win.setLoading(button, true, 'Loading...');
+  expect(button.disabled).toBe(true);
+  expect(button.textContent).toBe('Loading...');
+  win.setLoading(button, false);
+  expect(button.disabled).toBe(false);
+  expect(button.innerHTML).toBe(originalHtml);
+  expect(button.dataset.originalHtml).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- preserve full button markup while in loading state
- test setLoading with nested button HTML

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab6b733754832bad18e5141997fa8d