### PR TITLE
Avoid prototype keys in CSV exports

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -622,9 +622,9 @@ function exportRecordsCSV() {
 function exportEmployeesCSV() {
   let csvContent = "data:text/csv;charset=utf-8,";
   csvContent += "Badge ID,Employee Name\n";
-  for (let badge in employees) {
-    csvContent += `"${csvEscape(badge)}","${csvEscape(employees[badge])}"\n`;
-  }
+  Object.entries(employees).forEach(([badge, name]) => {
+    csvContent += `"${csvEscape(badge)}","${csvEscape(name)}"\n`;
+  });
   const link = document.createElement("a");
   link.href = encodeURI(csvContent);
   link.download = "employees.csv";
@@ -636,9 +636,9 @@ function exportEmployeesCSV() {
 function exportEquipmentCSV() {
   let csvContent = "data:text/csv;charset=utf-8,";
   csvContent += "Equipment Serial,Equipment Name\n";
-  for (let serial in equipmentItems) {
-    csvContent += `"${csvEscape(serial)}","${csvEscape(equipmentItems[serial])}"\n`;
-  }
+  Object.entries(equipmentItems).forEach(([serial, name]) => {
+    csvContent += `"${csvEscape(serial)}","${csvEscape(name)}"\n`;
+  });
   const link = document.createElement("a");
   link.href = encodeURI(csvContent);
   link.download = "equipment.csv";

--- a/tests/exportCSV.test.js
+++ b/tests/exportCSV.test.js
@@ -126,3 +126,35 @@ test('exportRecordsCSV leaves blank cells for missing fields', () => {
   expect(row).toBe('"2023-01-01T00:00:00","","","","",""');
   spy.mockRestore();
 });
+
+test('exportEmployeesCSV ignores inherited prototype properties', () => {
+  Object.prototype.protoEmployee = 'Prototype';
+  try {
+    const win = setupDom({ employees: { '1': 'John Doe' } });
+    const spy = jest.spyOn(document.body, 'appendChild');
+    win.exportEmployeesCSV();
+    const link = spy.mock.calls[0][0];
+    const csv = decodeURI(link.href).split('charset=utf-8,')[1];
+    const expected = `Badge ID,Employee Name\n"1","John Doe"\n`;
+    expect(csv).toBe(expected);
+    spy.mockRestore();
+  } finally {
+    delete Object.prototype.protoEmployee;
+  }
+});
+
+test('exportEquipmentCSV ignores inherited prototype properties', () => {
+  Object.prototype.protoEquipment = 'Prototype';
+  try {
+    const win = setupDom({ equipmentItems: { 'EQ1': 'Hammer' } });
+    const spy = jest.spyOn(document.body, 'appendChild');
+    win.exportEquipmentCSV();
+    const link = spy.mock.calls[0][0];
+    const csv = decodeURI(link.href).split('charset=utf-8,')[1];
+    const expected = `Equipment Serial,Equipment Name\n"EQ1","Hammer"\n`;
+    expect(csv).toBe(expected);
+    spy.mockRestore();
+  } finally {
+    delete Object.prototype.protoEquipment;
+  }
+});


### PR DESCRIPTION
## Summary
- Prevent prototype pollution in CSV exports by iterating with `Object.entries`
- Add regression tests ensuring inherited properties aren't exported

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab6f3ab878832b8b30944836e475c3