### PR TITLE
Preserve spaces during CSV import

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -685,8 +685,8 @@ function handleImportEmployees(event) {
     const text = e.target.result;
     const lines = text.split("\n");
     for (let i = 1; i < lines.length; i++) {
-      const line = lines[i].trim();
-      if (line === "") continue;
+      const line = lines[i].replace(/\r$/, '');
+      if (line.trim() === "") continue;
       const parts = parseCSVLine(line);
       if (parts.length < 2) {
         showError(`Skipping malformed line ${i + 1}: ${line}`);
@@ -730,8 +730,8 @@ function handleImportEquipment(event) {
     const text = e.target.result;
     const lines = text.split("\n");
     for (let i = 1; i < lines.length; i++) {
-      const line = lines[i].trim();
-      if (line === "") continue;
+      const line = lines[i].replace(/\r$/, '');
+      if (line.trim() === "") continue;
       const parts = parseCSVLine(line);
       if (parts.length < 2) {
         showError(`Skipping malformed line ${i + 1}: ${line}`);

--- a/tests/importHandlers.test.js
+++ b/tests/importHandlers.test.js
@@ -59,6 +59,42 @@ test('handleImportEquipment skips malformed lines', () => {
   expect(win.showError).toHaveBeenCalledWith(expect.stringContaining('line 3'));
 });
 
+test('handleImportEmployees imports values with surrounding spaces', () => {
+  const win = setupDom();
+  win.showError = jest.fn();
+  win.showSuccess = jest.fn();
+  win.displayEmployeeList = jest.fn();
+  class MockFileReader {
+    readAsText(file) {
+      this.onload && this.onload({ target: { result: file.text } });
+    }
+  }
+  win.FileReader = MockFileReader;
+  const csv = 'Badge ID,Employee Name\n 123 ,  John Doe  ';
+  const event = { target: { files: [ { text: csv } ], value: '' } };
+  win.handleImportEmployees(event);
+  const stored = JSON.parse(localStorage.getItem('employees'));
+  expect(stored).toEqual({ '123': 'John Doe' });
+});
+
+test('handleImportEquipment imports values with surrounding spaces', () => {
+  const win = setupDom();
+  win.showError = jest.fn();
+  win.showSuccess = jest.fn();
+  win.displayEquipmentListAdmin = jest.fn();
+  class MockFileReader {
+    readAsText(file) {
+      this.onload && this.onload({ target: { result: file.text } });
+    }
+  }
+  win.FileReader = MockFileReader;
+  const csv = 'Equipment Serial,Equipment Name\n EQ1 ,  Hammer  ';
+  const event = { target: { files: [ { text: csv } ], value: '' } };
+  win.handleImportEquipment(event);
+  const stored = JSON.parse(localStorage.getItem('equipmentItems'));
+  expect(stored).toEqual({ 'EQ1': 'Hammer' });
+});
+
 test('handleImportEmployees surfaces read errors', () => {
   const win = setupDom();
   win.showError = jest.fn();


### PR DESCRIPTION
## Summary
- Parse employee and equipment CSV rows without trimming leading/trailing spaces, only removing trailing carriage returns.
- Add tests to ensure rows with surrounding spaces are imported correctly.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab73c27624832b9cd90395532ad5b0