### PR TITLE
refactor: add reusable button class

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,12 +22,12 @@
   <div id="notifications" role="alert" aria-live="polite"></div>
 
   <!-- Navigation -->
-  <button id="navToggle" class="nav-toggle btn-primary" aria-expanded="false" aria-controls="mainNav" aria-label="Menu"><span class="material-symbols-outlined nav-icon">menu</span><span class="nav-text">Menu</span></button>
+  <button id="navToggle" class="nav-toggle btn btn-primary" aria-expanded="false" aria-controls="mainNav" aria-label="Menu"><span class="material-symbols-outlined nav-icon">menu</span><span class="nav-text">Menu</span></button>
   <nav id="mainNav" aria-hidden="true">
     <ul class="nav-container">
-      <li><a href="#" id="navCheckout" data-section="checkout"><span class="material-symbols-outlined nav-icon">barcode_reader</span> Check-Out</a></li>
-      <li><a href="#" id="navAdmin" data-section="admin"><span class="material-symbols-outlined nav-icon">admin_panel_settings</span> Admin</a></li>
-      <li><a href="#" id="navRecords" data-section="records"><span class="material-symbols-outlined nav-icon">data_table</span> Records</a></li>
+      <li><a href="#" id="navCheckout" data-section="checkout" class="btn btn-primary"><span class="material-symbols-outlined nav-icon">barcode_reader</span> Check-Out</a></li>
+      <li><a href="#" id="navAdmin" data-section="admin" class="btn btn-primary"><span class="material-symbols-outlined nav-icon">admin_panel_settings</span> Admin</a></li>
+      <li><a href="#" id="navRecords" data-section="records" class="btn btn-primary"><span class="material-symbols-outlined nav-icon">data_table</span>Records</a></li>
     </ul>
   </nav>
 
@@ -49,20 +49,20 @@
             <span id="equipment0Error" class="error-message" aria-live="polite"></span>
             <span class="equipmentNameDisplay"></span>
           </div>
-          <button type="button" class="removeEquipment hidden btn-danger">Remove</button>
+          <button type="button" class="removeEquipment hidden btn btn-danger">Remove</button>
         </div>
       </div>
-      <button type="button" id="addEquipmentBtn" class="btn-primary">Add Another Barcode</button>
+      <button type="button" id="addEquipmentBtn" class="btn btn-primary">Add Another Barcode</button>
       <label for="actionBtn">Action:</label>
       <div class="dropdown">
-        <button type="button" id="actionBtn" class="btn-inline btn-primary" aria-haspopup="true" aria-expanded="false" aria-controls="actionMenu">Select Action</button>
+        <button type="button" id="actionBtn" class="btn btn-inline btn-primary" aria-haspopup="true" aria-expanded="false" aria-controls="actionMenu">Select Action</button>
         <div id="actionMenu" class="dropdown-menu hidden" role="menu">
           <button type="button" data-value="Check-Out" role="menuitem">Check-Out</button>
           <button type="button" data-value="Check-In" role="menuitem">Check-In</button>
         </div>
       </div>
       <input type="hidden" id="action">
-      <button type="submit" class="btn-primary btn-block">Submit</button>
+      <button type="submit" class="btn btn-primary btn-block">Submit</button>
     </form>
   </section>
 
@@ -80,7 +80,7 @@
         <input type="text" id="empBadge" placeholder="Enter Badge ID" required aria-describedby="empBadgeError">
         <span id="empBadgeError" class="error-message" aria-live="polite"></span>
       </div>
-      <button type="submit" id="addEmployeeBtn" class="btn-primary btn-block">Add Employee</button>
+      <button type="submit" id="addEmployeeBtn" class="btn btn-primary btn-block">Add Employee</button>
     </form>
     <h3>Current Employees</h3>
     <label for="employeeSearch" class="sr-only">Search employees</label>
@@ -89,9 +89,9 @@
       <ul id="employeeList"><li class="placeholder">No employees added yet.</li></ul>
     </div>
     <div class="pagination-controls">
-      <button type="button" id="employeePrev" class="btn-inline material-symbols-outlined hidden btn-primary" aria-label="Previous page">chevron_left</button>
+      <button type="button" id="employeePrev" class="btn btn-inline material-symbols-outlined hidden btn-primary" aria-label="Previous page">chevron_left</button>
       <span id="employeePageIndicator" class="page-indicator"></span>
-      <button type="button" id="employeeNext" class="btn-inline material-symbols-outlined btn-primary" aria-label="Next page">chevron_right</button>
+      <button type="button" id="employeeNext" class="btn btn-inline material-symbols-outlined btn-primary" aria-label="Next page">chevron_right</button>
     </div>
     <hr>
     <h2>Manage Equipment</h2>
@@ -106,7 +106,7 @@
         <input type="text" id="equipSerial" placeholder="Enter Equipment Serial" required aria-describedby="equipSerialError">
         <span id="equipSerialError" class="error-message" aria-live="polite"></span>
       </div>
-      <button type="submit" id="addEquipmentAdminBtn" class="btn-primary btn-block">Add Equipment</button>
+      <button type="submit" id="addEquipmentAdminBtn" class="btn btn-primary btn-block">Add Equipment</button>
     </form>
     <h3>Current Equipment</h3>
     <label for="equipmentSearch" class="sr-only">Search equipment</label>
@@ -115,16 +115,16 @@
       <ul id="equipmentListAdmin"><li class="placeholder">No equipment added yet.</li></ul>
     </div>
     <div class="pagination-controls">
-      <button type="button" id="equipmentPrev" class="btn-inline material-symbols-outlined hidden btn-primary" aria-label="Previous page">chevron_left</button>
+      <button type="button" id="equipmentPrev" class="btn btn-inline material-symbols-outlined hidden btn-primary" aria-label="Previous page">chevron_left</button>
       <span id="equipmentPageIndicator" class="page-indicator"></span>
-      <button type="button" id="equipmentNext" class="btn-inline material-symbols-outlined btn-primary" aria-label="Next page">chevron_right</button>
+      <button type="button" id="equipmentNext" class="btn btn-inline material-symbols-outlined btn-primary" aria-label="Next page">chevron_right</button>
     </div>
 
     <!-- New Import/Export Section -->
     <hr>
     <div class="mb-15">
       <div class="dropdown">
-        <button type="button" class="btn-inline btn-primary" id="importExportBtn" aria-haspopup="true" aria-expanded="false" aria-controls="importExportMenu">Import/Export</button>
+        <button type="button" class="btn btn-inline btn-primary" id="importExportBtn" aria-haspopup="true" aria-expanded="false" aria-controls="importExportMenu">Import/Export</button>
         <div id="importExportMenu" class="dropdown-menu hidden" role="menu">
           <button type="button" id="exportEmployeesAction" role="menuitem">Export Employees to CSV</button>
           <button type="button" id="importEmployeesAction" role="menuitem">Import Employees CSV</button>
@@ -149,10 +149,10 @@
         <input type="text" id="recordEquipment" placeholder="Search by equipment name or serial">
         <label for="recordDate" class="sr-only">Filter by date</label>
         <input type="date" id="recordDate">
-        <button type="submit" id="filterRecordsBtn" class="btn-secondary">Search/Filter</button>
-        <button type="button" id="clearFiltersBtn" class="btn-secondary">Clear Filters</button>
+        <button type="submit" id="filterRecordsBtn" class="btn btn-secondary">Search/Filter</button>
+        <button type="button" id="clearFiltersBtn" class="btn btn-secondary">Clear Filters</button>
       </form>
-      <button type="button" id="exportRecordsBtn" class="btn-primary">Export Records to CSV</button>
+      <button type="button" id="exportRecordsBtn" class="btn btn-primary">Export Records to CSV</button>
       <div id="recordsTable"></div>
     </div>
   </section>

--- a/styles/main.css
+++ b/styles/main.css
@@ -36,7 +36,7 @@
       border-radius: 0.5rem;
       box-shadow: 0 0 0.625rem rgba(0,0,0,0.1);
     }
-    input, select, button, textarea {
+    input, select, .btn, textarea {
       padding: 0.625rem;
       margin: 0.625rem 0;
       box-sizing: border-box;
@@ -48,7 +48,7 @@
       color: red;
       font-size: 0.875rem;
     }
-    button {
+    .btn {
       color: white;
       border: none;
       cursor: pointer;
@@ -186,17 +186,14 @@
       flex: 0 1 auto;
     }
     nav .nav-container a {
-      width: auto;
       white-space: nowrap;
       text-decoration: none;
-      color: white;
       font-weight: bold;
-      background-color: var(--color-primary);
       padding: 0.5rem 0.9375rem;
-      border-radius: 0.5rem;
       display: flex;
       align-items: center;
       gap: 0.25rem;
+      margin: 0;
     }
     nav .nav-container a.active {
       background-color: #4d148c;
@@ -211,7 +208,8 @@
         padding: 0.5rem 0.9375rem;
         width: auto;
         flex: 0 1 auto;
-      }
+        margin: 0;
+    }
 
     .nav-icon {
       font-size: 1.2rem;
@@ -283,7 +281,7 @@
       flex: 1;
       min-width: 9.375rem;
     }
-    #recordFilterForm button {
+    #recordFilterForm .btn {
       padding: 0.5rem 0.9375rem;
       border-radius: 0.5rem;
     }
@@ -386,9 +384,9 @@
       }
 
       .employeeRow input,
-      .employeeRow button,
+      .employeeRow .btn,
       .equipmentRow input,
-      .equipmentRow button {
+      .equipmentRow .btn {
         width: 100%;
       }
 


### PR DESCRIPTION
## Summary
- introduce `.btn` class for shared button styling
- streamline navigation links to use `.btn` and `.btn-primary`
- update HTML buttons to use new base class

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab771c9470832b978a8147d67a9659