### PR TITLE
Add focus-visible outlines for interactive elements

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -2,6 +2,15 @@
       --color-primary: #ff6600;
       --color-accent: #0073e6;
       --color-danger: #cc0000;
+      --focus-ring-inner: #fff;
+      --focus-ring-outer: #000;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --focus-ring-inner: #000;
+        --focus-ring-outer: #fff;
+      }
     }
 
     html {
@@ -40,6 +49,15 @@
       padding: 0.625rem;
       margin: 0.625rem 0;
       box-sizing: border-box;
+    }
+    .btn:focus-visible,
+    a:focus-visible,
+    input:focus-visible,
+    select:focus-visible,
+    textarea:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 0.125rem var(--focus-ring-inner),
+                  0 0 0 0.25rem var(--focus-ring-outer);
     }
     .error {
       border: 0.125rem solid red;


### PR DESCRIPTION
## Summary
- provide high-contrast focus-visible rings for buttons, links, and form fields
- support dark mode by toggling focus ring colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab7d14caf4832b9c389152dbae016b