### PR TITLE
refactor: use container max width variable

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -11,6 +11,7 @@
       --color-error: #721c24;
       --color-error-bg: #f8d7da;
       --color-error-border: #f5c6cb;
+      --container-max-width: 37.5rem;
       --focus-ring-inner: #fff;
       --focus-ring-outer: #000;
     }
@@ -48,7 +49,7 @@
     }
     form, #records .records-container {
       background: #fff;
-      max-width: 37.5rem;
+      max-width: var(--container-max-width);
       margin: 1.25rem auto;
       padding: 1.25rem;
       border-radius: 0.5rem;
@@ -290,7 +291,7 @@
     }
     .records-container {
       background: #fff;
-      max-width: 50rem;
+      max-width: var(--container-max-width);
       margin: 1.25rem auto;
       padding: 1.25rem;
       border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- add a `--container-max-width` CSS variable for shared layout widths
- apply the variable to `form` and `.records-container` to remove hard-coded values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8ad13df0832b859ef394082a4d09