### PR TITLE
Improve CSV parsing and newline preservation

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -28,10 +28,7 @@ function saveToStorage(key, data) {
 }
 
 function csvEscape(value) {
-  return String(value)
-    .replace(/\r/g, '\\r')
-    .replace(/\n/g, '\\n')
-    .replace(/"/g, '""');
+  return String(value).replace(/"/g, '""');
 }
 
 /* ---------- Notification System ---------- */
@@ -690,13 +687,11 @@ function handleImportEmployees(event) {
   };
   reader.onload = function(e) {
     const text = e.target.result;
-    const lines = text.split("\n");
-    for (let i = 1; i < lines.length; i++) {
-      const line = lines[i].replace(/\r$/, '');
-      if (line.trim() === "") continue;
-      const parts = parseCSVLine(line);
+    const rows = parseCSV(text);
+    for (let i = 1; i < rows.length; i++) {
+      const parts = rows[i];
       if (parts.length < 2) {
-        showError(`Skipping malformed line ${i + 1}: ${line}`);
+        showError(`Skipping malformed line ${i + 1}: ${parts.join(',')}`);
         continue;
       }
       let badge = parts[0].replace(/^"|"$/g, '').trim();
@@ -735,13 +730,11 @@ function handleImportEquipment(event) {
   };
   reader.onload = function(e) {
     const text = e.target.result;
-    const lines = text.split("\n");
-    for (let i = 1; i < lines.length; i++) {
-      const line = lines[i].replace(/\r$/, '');
-      if (line.trim() === "") continue;
-      const parts = parseCSVLine(line);
+    const rows = parseCSV(text);
+    for (let i = 1; i < rows.length; i++) {
+      const parts = rows[i];
       if (parts.length < 2) {
-        showError(`Skipping malformed line ${i + 1}: ${line}`);
+        showError(`Skipping malformed line ${i + 1}: ${parts.join(',')}`);
         continue;
       }
       let serial = parts[0].replace(/^"|"$/g, '').trim();

--- a/scripts/csvParser.js
+++ b/scripts/csvParser.js
@@ -1,30 +1,39 @@
-function parseCSVLine(line) {
-  if (line.endsWith('\r')) {
-    line = line.slice(0, -1);
-  }
-  const result = [];
+function parseCSV(text) {
+  const rows = [];
   let current = '';
+  let row = [];
   let inQuotes = false;
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
     if (char === '"') {
-      if (inQuotes && line[i + 1] === '"') {
+      if (inQuotes && text[i + 1] === '"') {
         current += '"';
         i++;
       } else {
         inQuotes = !inQuotes;
       }
     } else if (char === ',' && !inQuotes) {
-      result.push(current);
+      row.push(current);
+      current = '';
+    } else if ((char === '\n' || char === '\r') && !inQuotes) {
+      if (char === '\r' && text[i + 1] === '\n') {
+        i++;
+      }
+      row.push(current);
+      rows.push(row);
+      row = [];
       current = '';
     } else {
       current += char;
     }
   }
-  result.push(current);
-  return result;
+  if (current !== '' || row.length > 0) {
+    row.push(current);
+    rows.push(row);
+  }
+  return rows;
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = { parseCSVLine };
+  module.exports = { parseCSV };
 }

--- a/tests/csvParser.test.js
+++ b/tests/csvParser.test.js
@@ -1,16 +1,25 @@
-const { parseCSVLine } = require('../scripts/csvParser');
+const { parseCSV } = require('../scripts/csvParser');
 
-describe('parseCSVLine', () => {
-  test('parses simple CSV line', () => {
-    expect(parseCSVLine('123,John Doe')).toEqual(['123', 'John Doe']);
+describe('parseCSV', () => {
+  test('parses simple CSV file', () => {
+    expect(parseCSV('123,John Doe')).toEqual([[ '123', 'John Doe' ]]);
   });
 
   test('handles quoted commas', () => {
-    expect(parseCSVLine('"123","Doe, John"')).toEqual(['123', 'Doe, John']);
+    expect(parseCSV('"123","Doe, John"')).toEqual([[ '123', 'Doe, John' ]]);
   });
 
-  test('parses line ending with \r\n', () => {
-    const line = '123,John Doe\r\n'.split('\n')[0];
-    expect(parseCSVLine(line)).toEqual(['123', 'John Doe']);
+  test('parses CRLF line endings', () => {
+    const csv = '123,John Doe\r\n';
+    expect(parseCSV(csv)).toEqual([[ '123', 'John Doe' ]]);
+  });
+
+  test('parses embedded newlines within quoted fields', () => {
+    const csv = '"1","John\nDoe"\n"2","Jane\r\nSmith"';
+    expect(parseCSV(csv)).toEqual([
+      ['1', 'John\nDoe'],
+      ['2', 'Jane\r\nSmith']
+    ]);
   });
 });
+

--- a/tests/exportCSV.test.js
+++ b/tests/exportCSV.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
+const { parseCSV } = require('../scripts/csvParser');
 
 const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
 const script = fs.readFileSync(path.resolve(__dirname, '../scripts/app.js'), 'utf8');
@@ -74,8 +75,10 @@ test('exportEmployeesCSV escapes newline characters in names', () => {
   win.exportEmployeesCSV();
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-  const expected = `Badge ID,Employee Name\n"1","John\\r\\nDoe"\n`;
+  const expected = `Badge ID,Employee Name\n"1","John\r\nDoe"\n`;
   expect(csv).toBe(expected);
+  const parsed = parseCSV(csv);
+  expect(parsed[1][1]).toBe('John\r\nDoe');
   spy.mockRestore();
 });
 
@@ -85,8 +88,10 @@ test('exportEquipmentCSV escapes newline characters in names', () => {
   win.exportEquipmentCSV();
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-  const expected = `Equipment Serial,Equipment Name\n"EQ1","Hammer\\r\\nXL"\n`;
+  const expected = `Equipment Serial,Equipment Name\n"EQ1","Hammer\r\nXL"\n`;
   expect(csv).toBe(expected);
+  const parsed = parseCSV(csv);
+  expect(parsed[1][1]).toBe('Hammer\r\nXL');
   spy.mockRestore();
 });
 
@@ -105,8 +110,11 @@ test('exportRecordsCSV escapes newline characters in fields', () => {
   win.exportRecordsCSV();
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-  const expected = `Timestamp,Employee Badge ID,Employee Name,Equipment Barcodes,Equipment Names,Action\n"2023-01-01T00:00:00","1","John\\r\\nDoe","EQ1","Hammer\\r\\nXL","Check-Out"`;
+  const expected = `Timestamp,Employee Badge ID,Employee Name,Equipment Barcodes,Equipment Names,Action\n"2023-01-01T00:00:00","1","John\r\nDoe","EQ1","Hammer\r\nXL","Check-Out"`;
   expect(csv).toBe(expected);
+  const parsed = parseCSV(csv);
+  expect(parsed[1][2]).toBe('John\r\nDoe');
+  expect(parsed[1][4]).toBe('Hammer\r\nXL');
   spy.mockRestore();
 });
 


### PR DESCRIPTION
## Summary
- Replace naive line-based CSV parsing with character-by-character parser
- Preserve embedded CRLF when exporting CSV data
- Test CSV parsing and export with fields containing newlines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb3494bc0832baf0471bd4c0b7221