### PR TITLE
Reset temp notifications when no delay

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -35,6 +35,15 @@ function csvEscape(value) {
 let notificationTimer;
 let tempNotificationActive = false;
 
+function clearNotification() {
+  const notificationDiv = document.getElementById('notifications');
+  notificationDiv.classList.remove('visible');
+  notificationDiv.className = '';
+  notificationDiv.textContent = '';
+  tempNotificationActive = false;
+  updateNotifications();
+}
+
 function showNotification(message, type, delay = 3000) {
   const notificationDiv = document.getElementById('notifications');
   if (notificationTimer) {
@@ -47,13 +56,9 @@ function showNotification(message, type, delay = 3000) {
   notificationDiv.classList.add('visible');
 
   if (delay > 0) {
-    notificationTimer = setTimeout(() => {
-      notificationDiv.classList.remove('visible');
-      notificationDiv.className = '';
-      notificationDiv.textContent = '';
-      tempNotificationActive = false;
-      updateNotifications();
-    }, delay);
+    notificationTimer = setTimeout(clearNotification, delay);
+  } else {
+    clearNotification();
   }
 }
 

--- a/tests/showNotificationZeroDelay.test.js
+++ b/tests/showNotificationZeroDelay.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+const script = fs.readFileSync(path.resolve(__dirname, '../scripts/app.js'), 'utf8');
+
+function setupDom() {
+  const dom = new JSDOM(html, { url: 'http://localhost', runScripts: 'dangerously' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.localStorage = window.localStorage;
+  window.eval(script);
+  return window;
+}
+
+afterEach(() => {
+  delete global.window;
+  delete global.document;
+  delete global.localStorage;
+});
+
+test('showNotification with delay 0 allows subsequent notifications', () => {
+  const win = setupDom();
+  const notificationDiv = win.document.getElementById('notifications');
+
+  jest.useFakeTimers();
+  win.showNotification('First', 'success', 0);
+  jest.runAllTimers();
+  expect(notificationDiv.textContent).toBe('');
+
+  win.showNotification('Second', 'error', 1000);
+  expect(notificationDiv.textContent).toBe('Second');
+  jest.runAllTimers();
+  jest.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- add `clearNotification` helper to reset notification state
- clear temp notifications immediately when delay is 0 to avoid blocking future updates
- test that 0-delay notifications don't block later messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb5ff6a94832b85f7737a4b6b5b1f