### PR TITLE
Close dropdown on Tab key

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -857,6 +857,9 @@ function setupDropdown(button, menu, onSelect) {
       } else if (e.key === 'Escape') {
         e.preventDefault();
         closeMenu();
+      } else if (e.key === 'Tab') {
+        e.preventDefault();
+        closeMenu();
       }
     });
   });

--- a/tests/navigation.test.js
+++ b/tests/navigation.test.js
@@ -49,3 +49,17 @@ test('nav is visible by default', () => {
   expect(win.getComputedStyle(nav).display).not.toBe('none');
 });
 
+test('pressing Tab on last menu item closes dropdown', () => {
+  const win = setupDom();
+  const btn = win.document.getElementById('actionBtn');
+  const menu = win.document.getElementById('actionMenu');
+  // open the dropdown
+  btn.click();
+  const items = menu.querySelectorAll('button');
+  const lastItem = items[items.length - 1];
+  lastItem.focus();
+  lastItem.dispatchEvent(new win.KeyboardEvent('keydown', { key: 'Tab' }));
+  expect(menu.classList.contains('hidden')).toBe(true);
+  expect(win.document.activeElement).toBe(btn);
+});
+


### PR DESCRIPTION
## Summary
- Close dropdown menus when Tab is pressed on a menu item and restore focus to the toggle button
- Add regression test verifying dropdown closes on Tab from the last menu item

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abb8e448d8832b9d474a1cb5fcc03c