### PR TITLE
Prompt before overwriting CSV imports

### DIFF
--- a/scripts/records.js
+++ b/scripts/records.js
@@ -169,6 +169,14 @@ function handleImportEmployees(event) {
       let badge = parts[0].replace(/^"|"$/g, '').trim();
       let name = parts[1].replace(/^"|"$/g, '').trim();
       if (badge && name) {
+        if (employees[badge]) {
+          const overwrite = typeof confirm === 'function'
+            ? confirm(`Badge ID ${badge} already exists. Overwrite?`)
+            : true;
+          if (!overwrite) {
+            continue;
+          }
+        }
         employees[badge] = name;
       }
     }
@@ -220,6 +228,14 @@ function handleImportEquipment(event) {
       let serial = parts[0].replace(/^"|"$/g, '').trim();
       let name = parts[1].replace(/^"|"$/g, '').trim();
       if (serial && name) {
+        if (equipmentItems[serial]) {
+          const overwrite = typeof confirm === 'function'
+            ? confirm(`Equipment ID ${serial} already exists. Overwrite?`)
+            : true;
+          if (!overwrite) {
+            continue;
+          }
+        }
         equipmentItems[serial] = name;
       }
     }

--- a/tests/importHandlers.test.js
+++ b/tests/importHandlers.test.js
@@ -160,6 +160,48 @@ test('handleImportEquipment restores button after failure', () => {
   expect(win.showError).toHaveBeenCalled();
 });
 
+test('handleImportEmployees prompts before overwriting existing IDs', () => {
+  const win = setupDom();
+  win.showError = jest.fn();
+  win.showSuccess = jest.fn();
+  win.displayEmployeeList = jest.fn();
+  win.confirm = jest.fn().mockReturnValue(false);
+  class MockFileReader {
+    readAsText(file) {
+      this.onload && this.onload({ target: { result: file.text } });
+    }
+  }
+  win.FileReader = MockFileReader;
+  let event = { target: { files: [ { text: 'Badge ID,Employee Name\n123,Original' } ], value: '' } };
+  win.handleImportEmployees(event);
+  event = { target: { files: [ { text: 'Badge ID,Employee Name\n123,Updated' } ], value: '' } };
+  win.handleImportEmployees(event);
+  expect(win.confirm).toHaveBeenCalledWith(expect.stringContaining('123'));
+  const stored = JSON.parse(localStorage.getItem('employees'));
+  expect(stored).toEqual({ '123': 'Original' });
+});
+
+test('handleImportEquipment prompts before overwriting existing IDs', () => {
+  const win = setupDom();
+  win.showError = jest.fn();
+  win.showSuccess = jest.fn();
+  win.displayEquipmentListAdmin = jest.fn();
+  win.confirm = jest.fn().mockReturnValue(false);
+  class MockFileReader {
+    readAsText(file) {
+      this.onload && this.onload({ target: { result: file.text } });
+    }
+  }
+  win.FileReader = MockFileReader;
+  let event = { target: { files: [ { text: 'Equipment Serial,Equipment Name\nEQ1,Hammer' } ], value: '' } };
+  win.handleImportEquipment(event);
+  event = { target: { files: [ { text: 'Equipment Serial,Equipment Name\nEQ1,Sledge' } ], value: '' } };
+  win.handleImportEquipment(event);
+  expect(win.confirm).toHaveBeenCalledWith(expect.stringContaining('EQ1'));
+  const stored = JSON.parse(localStorage.getItem('equipmentItems'));
+  expect(stored).toEqual({ 'EQ1': 'Hammer' });
+});
+
 test('setLoading restores nested button HTML', () => {
   const win = setupDom();
   const button = win.document.createElement('button');


### PR DESCRIPTION
## Summary
- prompt before overwriting existing employees or equipment during CSV imports
- skip overwriting when user declines the confirmation
- test import handlers for duplicate detection and decline behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abc7b53e44832ba02c10df4906a628