### PR TITLE
Add home station field for employees and equipment

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,11 @@
         <input type="text" id="empBadge" placeholder="Enter Badge ID" required aria-describedby="empBadgeError">
         <span id="empBadgeError" class="error-message" aria-live="polite"></span>
       </div>
+      <div>
+        <label for="empStation">Home Station:</label>
+        <input type="text" id="empStation" placeholder="Enter Home Station" required aria-describedby="empStationError">
+        <span id="empStationError" class="error-message" aria-live="polite"></span>
+      </div>
       <button type="submit" id="addEmployeeBtn" class="btn btn-primary btn-block">Add Employee</button>
     </form>
     <h3>Current Employees</h3>
@@ -104,6 +109,11 @@
         <label for="equipSerial">Equipment Serial Number:</label>
         <input type="text" id="equipSerial" placeholder="Enter Equipment Serial" required aria-describedby="equipSerialError">
         <span id="equipSerialError" class="error-message" aria-live="polite"></span>
+      </div>
+      <div>
+        <label for="equipStation">Home Station:</label>
+        <input type="text" id="equipStation" placeholder="Enter Home Station" required aria-describedby="equipStationError">
+        <span id="equipStationError" class="error-message" aria-live="polite"></span>
       </div>
       <button type="submit" id="addEquipmentAdminBtn" class="btn btn-primary btn-block">Add Equipment</button>
     </form>

--- a/scripts/admin.js
+++ b/scripts/admin.js
@@ -3,8 +3,10 @@ function displayEmployeeList(page = employeePage, filter = employeeFilter) {
   const list = document.getElementById('employeeList');
   list.innerHTML = "";
   const entries = Object.entries(employees).sort((a, b) => a[0].localeCompare(b[0]));
-  const filtered = entries.filter(([badge, name]) =>
-    badge.toLowerCase().includes(filter) || name.toLowerCase().includes(filter)
+  const filtered = entries.filter(([badge, info]) =>
+    badge.toLowerCase().includes(filter) ||
+    info.name.toLowerCase().includes(filter) ||
+    info.homeStation.toLowerCase().includes(filter)
   );
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   page = Math.min(Math.max(page, 0), totalPages - 1);
@@ -16,10 +18,10 @@ function displayEmployeeList(page = employeePage, filter = employeeFilter) {
     placeholder.textContent = 'No employees added yet.';
     list.appendChild(placeholder);
   } else {
-    pageItems.forEach(([badge, name]) => {
+    pageItems.forEach(([badge, info]) => {
       const li = document.createElement('li');
       const textSpan = document.createElement('span');
-      textSpan.textContent = `${badge}: ${name}`;
+      textSpan.textContent = `${badge}: ${info.name} (${info.homeStation})`;
       const del = document.createElement('button');
       del.type = 'button';
       del.className = 'deleteEmployee';
@@ -53,10 +55,13 @@ function displayEmployeeList(page = employeePage, filter = employeeFilter) {
 function addEmployee() {
   const nameInput = document.getElementById('empName');
   const badgeInput = document.getElementById('empBadge');
+  const stationInput = document.getElementById('empStation');
   clearFieldError(nameInput);
   clearFieldError(badgeInput);
+  clearFieldError(stationInput);
   const badge = badgeInput.value.trim();
   const name = nameInput.value.trim();
+  const homeStation = stationInput.value.trim();
   let hasError = false;
   if (!name) {
     setFieldError(nameInput, 'Employee name is required.');
@@ -66,19 +71,24 @@ function addEmployee() {
     setFieldError(badgeInput, 'Badge ID is required.');
     hasError = true;
   }
+  if (!homeStation) {
+    setFieldError(stationInput, 'Home station is required.');
+    hasError = true;
+  }
   if (hasError) return;
   if (employees[badge]) {
     setFieldError(badgeInput, 'Badge ID already exists.');
     showError('Employee with this badge ID already exists!');
     return;
   }
-  employees[badge] = name;
+  employees[badge] = { name, homeStation };
   saveToStorage('employees', employees);
   showSuccess('Employee added successfully!');
   displayEmployeeList();
   document.getElementById('adminForm').reset();
   clearFieldError(nameInput);
   clearFieldError(badgeInput);
+  clearFieldError(stationInput);
 }
 
 function removeEmployee(badge) {
@@ -101,8 +111,10 @@ function displayEquipmentListAdmin(page = equipmentPage, filter = equipmentFilte
   const list = document.getElementById('equipmentListAdmin');
   list.innerHTML = "";
   const entries = Object.entries(equipmentItems).sort((a, b) => a[0].localeCompare(b[0]));
-  const filtered = entries.filter(([serial, name]) =>
-    serial.toLowerCase().includes(filter) || name.toLowerCase().includes(filter)
+  const filtered = entries.filter(([serial, info]) =>
+    serial.toLowerCase().includes(filter) ||
+    info.name.toLowerCase().includes(filter) ||
+    info.homeStation.toLowerCase().includes(filter)
   );
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   page = Math.min(Math.max(page, 0), totalPages - 1);
@@ -114,10 +126,10 @@ function displayEquipmentListAdmin(page = equipmentPage, filter = equipmentFilte
     placeholder.textContent = 'No equipment added yet.';
     list.appendChild(placeholder);
   } else {
-    pageItems.forEach(([serial, name]) => {
+    pageItems.forEach(([serial, info]) => {
       const li = document.createElement('li');
       const textSpan = document.createElement('span');
-      textSpan.textContent = `${serial}: ${name}`;
+      textSpan.textContent = `${serial}: ${info.name} (${info.homeStation})`;
       const del = document.createElement('button');
       del.type = 'button';
       del.className = 'deleteEquipment';
@@ -151,10 +163,13 @@ function displayEquipmentListAdmin(page = equipmentPage, filter = equipmentFilte
 function addEquipmentAdmin() {
   const nameInput = document.getElementById('equipName');
   const serialInput = document.getElementById('equipSerial');
+  const stationInput = document.getElementById('equipStation');
   clearFieldError(nameInput);
   clearFieldError(serialInput);
+  clearFieldError(stationInput);
   const serial = serialInput.value.trim();
   const name = nameInput.value.trim();
+  const homeStation = stationInput.value.trim();
   let hasError = false;
   if (!name) {
     setFieldError(nameInput, 'Equipment name is required.');
@@ -164,19 +179,24 @@ function addEquipmentAdmin() {
     setFieldError(serialInput, 'Equipment serial is required.');
     hasError = true;
   }
+  if (!homeStation) {
+    setFieldError(stationInput, 'Home station is required.');
+    hasError = true;
+  }
   if (hasError) return;
   if (equipmentItems[serial]) {
     setFieldError(serialInput, 'Equipment serial already exists.');
     showError('Equipment with this serial already exists!');
     return;
   }
-  equipmentItems[serial] = name;
+  equipmentItems[serial] = { name, homeStation };
   saveToStorage('equipmentItems', equipmentItems);
   showSuccess('Equipment added successfully!');
   displayEquipmentListAdmin();
   document.getElementById('equipmentAdminForm').reset();
   clearFieldError(nameInput);
   clearFieldError(serialInput);
+  clearFieldError(stationInput);
 }
 
 function removeEquipmentAdmin(serial) {

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,6 +1,17 @@
 /* ---------- Initialization ---------- */
 let employees = loadFromStorage('employees', {});
 let equipmentItems = loadFromStorage('equipmentItems', {});
+// Migrate any legacy string entries to objects
+for (const [badge, data] of Object.entries(employees)) {
+  if (typeof data === 'string') {
+    employees[badge] = { name: data, homeStation: '' };
+  }
+}
+for (const [serial, data] of Object.entries(equipmentItems)) {
+  if (typeof data === 'string') {
+    equipmentItems[serial] = { name: data, homeStation: '' };
+  }
+}
 let records = loadFromStorage('records', []);
 let equipmentIdCounter = 1;
 
@@ -119,7 +130,7 @@ function lookupEmployee() {
     return;
   }
   if (employees[badge]) {
-    nameDisplay.textContent = employees[badge];
+    nameDisplay.textContent = employees[badge].name;
   } else {
     nameDisplay.textContent = 'Unknown employee';
   }
@@ -147,7 +158,7 @@ function lookupEquipment(event) {
     return;
   }
   if (equipmentItems[code]) {
-    nameDisplay.textContent = equipmentItems[code];
+    nameDisplay.textContent = equipmentItems[code].name;
     input.disabled = true;
   } else {
     nameDisplay.textContent = 'Unknown equipment';
@@ -184,14 +195,14 @@ document.getElementById('checkoutForm').addEventListener('submit', function(e) {
     const code = input.value.trim();
     if (code) {
       equipmentBarcodes.push(code);
-      equipmentNamesList.push(equipmentItems[code] || 'Unknown equipment');
+      equipmentNamesList.push((equipmentItems[code] && equipmentItems[code].name) || 'Unknown equipment');
     }
   });
   const record = {
     timestamp: new Date().toISOString(),
     recordDate: new Date().toISOString().substring(0,10),
     badge: badge,
-    employeeName: employees[badge] || 'Unknown employee',
+    employeeName: (employees[badge] && employees[badge].name) || 'Unknown employee',
     equipmentBarcodes: equipmentBarcodes,
     equipmentNames: equipmentNamesList,
     action: action
@@ -243,7 +254,7 @@ document.getElementById('equipmentAdminForm').addEventListener('submit', (e) => 
   addEquipmentAdmin();
 });
 
-['empName','empBadge','equipName','equipSerial'].forEach(id => {
+['empName','empBadge','empStation','equipName','equipSerial','equipStation'].forEach(id => {
   const el = document.getElementById(id);
   if (el) {
     el.addEventListener('input', () => clearFieldError(el));

--- a/scripts/notifications.js
+++ b/scripts/notifications.js
@@ -75,7 +75,7 @@ function updateNotifications() {
   const overdue = [];
   for (let code in status) {
     if (status[code] > 0) {
-      const name = equipmentItems[code] || "Unknown Equipment";
+      const name = (equipmentItems[code] && equipmentItems[code].name) || "Unknown Equipment";
       overdue.push(`${code} (${name})`);
     }
   }

--- a/scripts/records.js
+++ b/scripts/records.js
@@ -94,8 +94,8 @@ function exportRecordsCSV() {
 function exportEmployeesCSV() {
   let csvContent = "data:text/csv;charset=utf-8,";
   csvContent += "Badge ID,Employee Name\n";
-  Object.entries(employees).forEach(([badge, name]) => {
-    csvContent += `"${csvEscape(badge)}","${csvEscape(name)}"\n`;
+  Object.entries(employees).forEach(([badge, info]) => {
+    csvContent += `"${csvEscape(badge)}","${csvEscape(info.name)}"\n`;
   });
   const link = document.createElement("a");
   link.href = encodeURI(csvContent);
@@ -108,8 +108,8 @@ function exportEmployeesCSV() {
 function exportEquipmentCSV() {
   let csvContent = "data:text/csv;charset=utf-8,";
   csvContent += "Equipment Serial,Equipment Name\n";
-  Object.entries(equipmentItems).forEach(([serial, name]) => {
-    csvContent += `"${csvEscape(serial)}","${csvEscape(name)}"\n`;
+  Object.entries(equipmentItems).forEach(([serial, info]) => {
+    csvContent += `"${csvEscape(serial)}","${csvEscape(info.name)}"\n`;
   });
   const link = document.createElement("a");
   link.href = encodeURI(csvContent);
@@ -177,7 +177,7 @@ function handleImportEmployees(event) {
             continue;
           }
         }
-        employees[badge] = name;
+        employees[badge] = { name, homeStation: '' };
       }
     }
     saveToStorage("employees", employees);
@@ -236,7 +236,7 @@ function handleImportEquipment(event) {
             continue;
           }
         }
-        equipmentItems[serial] = name;
+        equipmentItems[serial] = { name, homeStation: '' };
       }
     }
     saveToStorage("equipmentItems", equipmentItems);

--- a/tests/actionDropdown.test.js
+++ b/tests/actionDropdown.test.js
@@ -19,8 +19,8 @@ function setupDom() {
   global.document = window.document;
   global.localStorage = window.localStorage;
   window.alert = jest.fn();
-  localStorage.setItem('employees', JSON.stringify({ '123': 'John Doe' }));
-  localStorage.setItem('equipmentItems', JSON.stringify({ 'E1': 'Scanner' }));
+  localStorage.setItem('employees', JSON.stringify({ '123': { name: 'John Doe', homeStation: '' } }));
+  localStorage.setItem('equipmentItems', JSON.stringify({ 'E1': { name: 'Scanner', homeStation: '' } }));
   localStorage.setItem('records', JSON.stringify([]));
   window.eval(scripts);
   return window;

--- a/tests/exportCSV.test.js
+++ b/tests/exportCSV.test.js
@@ -35,7 +35,7 @@ afterEach(() => {
 });
 
 test('exportEmployeesCSV escapes quotes in names', () => {
-  const win = setupDom({ employees: { '1': 'John "JJ" Doe' } });
+  const win = setupDom({ employees: { '1': { name: 'John "JJ" Doe', homeStation: '' } } });
   const spy = jest.spyOn(document.body, 'appendChild');
   win.exportEmployeesCSV();
   const link = spy.mock.calls[0][0];
@@ -46,7 +46,7 @@ test('exportEmployeesCSV escapes quotes in names', () => {
 });
 
 test('exportEquipmentCSV escapes quotes in names', () => {
-  const win = setupDom({ equipmentItems: { 'EQ1': 'Hammer "XL"' } });
+  const win = setupDom({ equipmentItems: { 'EQ1': { name: 'Hammer "XL"', homeStation: '' } } });
   const spy = jest.spyOn(document.body, 'appendChild');
   win.exportEquipmentCSV();
   const link = spy.mock.calls[0][0];
@@ -77,7 +77,7 @@ test('exportRecordsCSV escapes quotes in fields', () => {
 });
 
 test('exportEmployeesCSV escapes newline characters in names', () => {
-  const win = setupDom({ employees: { '1': 'John\r\nDoe' } });
+  const win = setupDom({ employees: { '1': { name: 'John\r\nDoe', homeStation: '' } } });
   const spy = jest.spyOn(document.body, 'appendChild');
   win.exportEmployeesCSV();
   const link = spy.mock.calls[0][0];
@@ -90,7 +90,7 @@ test('exportEmployeesCSV escapes newline characters in names', () => {
 });
 
 test('exportEquipmentCSV escapes newline characters in names', () => {
-  const win = setupDom({ equipmentItems: { 'EQ1': 'Hammer\r\nXL' } });
+  const win = setupDom({ equipmentItems: { 'EQ1': { name: 'Hammer\r\nXL', homeStation: '' } } });
   const spy = jest.spyOn(document.body, 'appendChild');
   win.exportEquipmentCSV();
   const link = spy.mock.calls[0][0];
@@ -145,7 +145,7 @@ test('exportRecordsCSV leaves blank cells for missing fields', () => {
 test('exportEmployeesCSV ignores inherited prototype properties', () => {
   Object.prototype.protoEmployee = 'Prototype';
   try {
-    const win = setupDom({ employees: { '1': 'John Doe' } });
+    const win = setupDom({ employees: { '1': { name: 'John Doe', homeStation: '' } } });
     const spy = jest.spyOn(document.body, 'appendChild');
     win.exportEmployeesCSV();
     const link = spy.mock.calls[0][0];
@@ -161,7 +161,7 @@ test('exportEmployeesCSV ignores inherited prototype properties', () => {
 test('exportEquipmentCSV ignores inherited prototype properties', () => {
   Object.prototype.protoEquipment = 'Prototype';
   try {
-    const win = setupDom({ equipmentItems: { 'EQ1': 'Hammer' } });
+    const win = setupDom({ equipmentItems: { 'EQ1': { name: 'Hammer', homeStation: '' } } });
     const spy = jest.spyOn(document.body, 'appendChild');
     win.exportEquipmentCSV();
     const link = spy.mock.calls[0][0];

--- a/tests/importHandlers.test.js
+++ b/tests/importHandlers.test.js
@@ -42,7 +42,7 @@ test('handleImportEmployees skips malformed lines', () => {
   const event = { target: { files: [ { text: 'Badge ID,Employee Name\n123,John\n456' } ], value: '' } };
   win.handleImportEmployees(event);
   const stored = JSON.parse(localStorage.getItem('employees'));
-  expect(stored).toEqual({ '123': 'John' });
+  expect(stored).toEqual({ '123': { name: 'John', homeStation: '' } });
   expect(win.showError).toHaveBeenCalledWith(expect.stringContaining('line 3'));
 });
 
@@ -60,7 +60,7 @@ test('handleImportEquipment skips malformed lines', () => {
   const event = { target: { files: [ { text: 'Equipment Serial,Equipment Name\nEQ1,Hammer\nEQ2' } ], value: '' } };
   win.handleImportEquipment(event);
   const stored = JSON.parse(localStorage.getItem('equipmentItems'));
-  expect(stored).toEqual({ 'EQ1': 'Hammer' });
+  expect(stored).toEqual({ 'EQ1': { name: 'Hammer', homeStation: '' } });
   expect(win.showError).toHaveBeenCalledWith(expect.stringContaining('line 3'));
 });
 
@@ -79,7 +79,7 @@ test('handleImportEmployees imports values with surrounding spaces', () => {
   const event = { target: { files: [ { text: csv } ], value: '' } };
   win.handleImportEmployees(event);
   const stored = JSON.parse(localStorage.getItem('employees'));
-  expect(stored).toEqual({ '123': 'John Doe' });
+  expect(stored).toEqual({ '123': { name: 'John Doe', homeStation: '' } });
 });
 
 test('handleImportEquipment imports values with surrounding spaces', () => {
@@ -97,7 +97,7 @@ test('handleImportEquipment imports values with surrounding spaces', () => {
   const event = { target: { files: [ { text: csv } ], value: '' } };
   win.handleImportEquipment(event);
   const stored = JSON.parse(localStorage.getItem('equipmentItems'));
-  expect(stored).toEqual({ 'EQ1': 'Hammer' });
+  expect(stored).toEqual({ 'EQ1': { name: 'Hammer', homeStation: '' } });
 });
 
 test('handleImportEmployees surfaces read errors', () => {
@@ -178,7 +178,7 @@ test('handleImportEmployees prompts before overwriting existing IDs', () => {
   win.handleImportEmployees(event);
   expect(win.confirm).toHaveBeenCalledWith(expect.stringContaining('123'));
   const stored = JSON.parse(localStorage.getItem('employees'));
-  expect(stored).toEqual({ '123': 'Original' });
+  expect(stored).toEqual({ '123': { name: 'Original', homeStation: '' } });
 });
 
 test('handleImportEquipment prompts before overwriting existing IDs', () => {
@@ -199,7 +199,7 @@ test('handleImportEquipment prompts before overwriting existing IDs', () => {
   win.handleImportEquipment(event);
   expect(win.confirm).toHaveBeenCalledWith(expect.stringContaining('EQ1'));
   const stored = JSON.parse(localStorage.getItem('equipmentItems'));
-  expect(stored).toEqual({ 'EQ1': 'Hammer' });
+  expect(stored).toEqual({ 'EQ1': { name: 'Hammer', homeStation: '' } });
 });
 
 test('setLoading restores nested button HTML', () => {

--- a/tests/lookupEquipmentDuplicates.test.js
+++ b/tests/lookupEquipmentDuplicates.test.js
@@ -20,7 +20,7 @@ function setupDom() {
   global.localStorage = window.localStorage;
   window.alert = jest.fn();
   localStorage.setItem('employees', JSON.stringify({}));
-  localStorage.setItem('equipmentItems', JSON.stringify({ E1: 'Scanner' }));
+  localStorage.setItem('equipmentItems', JSON.stringify({ E1: { name: 'Scanner', homeStation: '' } }));
   localStorage.setItem('records', JSON.stringify([]));
   window.eval(scripts);
   return window;


### PR DESCRIPTION
## Summary
- add Home Station inputs for employees and equipment in admin panel
- store employees and equipment as objects with name and homeStation
- display and manage new homeStation data across admin, checkout, and import/export logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd2209214832ba33902d3a159bd7d