### PR TITLE
Derive station from badge and update record exports

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -198,11 +198,13 @@ document.getElementById('checkoutForm').addEventListener('submit', function(e) {
       equipmentNamesList.push((equipmentItems[code] && equipmentItems[code].name) || 'Unknown equipment');
     }
   });
+  const station = badge.slice(0, 3);
   const record = {
     timestamp: new Date().toISOString(),
     recordDate: new Date().toISOString().substring(0,10),
     badge: badge,
     employeeName: (employees[badge] && employees[badge].name) || 'Unknown employee',
+    station: station,
     equipmentBarcodes: equipmentBarcodes,
     equipmentNames: equipmentNamesList,
     action: action

--- a/scripts/records.js
+++ b/scripts/records.js
@@ -17,12 +17,13 @@ function displayRecords(recArray) {
     container.innerHTML = "<p>No records found.</p>";
     return;
   }
-  let html = "<table><caption>Equipment check-in/out records</caption><tr><th>Timestamp</th><th>Badge</th><th>Name</th><th>Equipment Barcodes</th><th>Equipment Names</th><th>Action</th></tr>";
+  let html = "<table><caption>Equipment check-in/out records</caption><tr><th>Timestamp</th><th>Badge</th><th>Name</th><th>Station</th><th>Equipment Barcodes</th><th>Equipment Names</th><th>Action</th></tr>";
   recArray.forEach(rec => {
     html += `<tr>
           <td>${escapeHtml(rec.timestamp)}</td>
           <td>${escapeHtml(rec.badge)}</td>
           <td>${escapeHtml(rec.employeeName)}</td>
+          <td>${escapeHtml(rec.station ?? '')}</td>
           <td>${escapeHtml((rec.equipmentBarcodes ?? []).join('; '))}</td>
           <td>${escapeHtml((rec.equipmentNames ?? []).join('; '))}</td>
           <td>${escapeHtml(rec.action)}</td>
@@ -73,11 +74,12 @@ function exportRecordsCSV() {
     }
     return;
   }
-  const header = "Timestamp,Employee Badge ID,Employee Name,Equipment Barcodes,Equipment Names,Action\n";
+  const header = "Timestamp,Employee Badge ID,Employee Name,Station,Equipment Barcodes,Equipment Names,Action\n";
   const rows = records.map(rec =>
     `"${csvEscape(rec.timestamp ?? '')}",` +
     `"${csvEscape(rec.badge ?? '')}",` +
     `"${csvEscape(rec.employeeName ?? '')}",` +
+    `"${csvEscape(rec.station ?? '')}",` +
     `"${csvEscape((rec.equipmentBarcodes ?? []).join('; ') ?? '')}",` +
     `"${csvEscape((rec.equipmentNames ?? []).join('; ') ?? '')}",` +
     `"${csvEscape(rec.action ?? '')}"`

--- a/tests/actionDropdown.test.js
+++ b/tests/actionDropdown.test.js
@@ -19,7 +19,7 @@ function setupDom() {
   global.document = window.document;
   global.localStorage = window.localStorage;
   window.alert = jest.fn();
-  localStorage.setItem('employees', JSON.stringify({ '123': { name: 'John Doe', homeStation: '' } }));
+  localStorage.setItem('employees', JSON.stringify({ '123456': { name: 'John Doe', homeStation: '' } }));
   localStorage.setItem('equipmentItems', JSON.stringify({ 'E1': { name: 'Scanner', homeStation: '' } }));
   localStorage.setItem('records', JSON.stringify([]));
   window.eval(scripts);
@@ -46,7 +46,7 @@ test('action dropdown toggles', () => {
 test('selected action stored on checkout submit', () => {
   const win = setupDom();
   const { document } = win;
-  document.getElementById('badge').value = '123';
+  document.getElementById('badge').value = '123456';
   document.getElementById('equipment0').value = 'E1';
   document.getElementById('actionBtn').click();
   document.querySelector('#actionMenu button[data-value="Check-Out"]').click();
@@ -60,5 +60,6 @@ test('selected action stored on checkout submit', () => {
   const records = JSON.parse(localStorage.getItem('records'));
   expect(records.length).toBe(1);
   expect(records[0].action).toBe('Check-Out');
+  expect(records[0].station).toBe('123');
 });
 

--- a/tests/exportCSV.test.js
+++ b/tests/exportCSV.test.js
@@ -61,6 +61,7 @@ test('exportRecordsCSV escapes quotes in fields', () => {
   timestamp: '2023-01-01T00:00:00',
   badge: '1',
   employeeName: 'John "JJ" Doe',
+  station: 'AAA',
   equipmentBarcodes: ['EQ1'],
   equipmentNames: ['Hammer "XL"'],
   action: 'Check-Out',
@@ -72,7 +73,7 @@ test('exportRecordsCSV escapes quotes in fields', () => {
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
   const row = csv.split('\n')[1];
-  expect(row).toBe('"2023-01-01T00:00:00","1","John ""JJ"" Doe","EQ1","Hammer ""XL""","Check-Out"');
+  expect(row).toBe('"2023-01-01T00:00:00","1","John ""JJ"" Doe","AAA","EQ1","Hammer ""XL""","Check-Out"');
   spy.mockRestore();
 });
 
@@ -107,6 +108,7 @@ test('exportRecordsCSV escapes newline characters in fields', () => {
     timestamp: '2023-01-01T00:00:00',
     badge: '1',
     employeeName: 'John\r\nDoe',
+    station: 'AAA',
     equipmentBarcodes: ['EQ1'],
     equipmentNames: ['Hammer\r\nXL'],
     action: 'Check-Out',
@@ -117,11 +119,11 @@ test('exportRecordsCSV escapes newline characters in fields', () => {
   win.exportRecordsCSV();
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-  const expected = `Timestamp,Employee Badge ID,Employee Name,Equipment Barcodes,Equipment Names,Action\n"2023-01-01T00:00:00","1","John\r\nDoe","EQ1","Hammer\r\nXL","Check-Out"`;
+  const expected = `Timestamp,Employee Badge ID,Employee Name,Station,Equipment Barcodes,Equipment Names,Action\n"2023-01-01T00:00:00","1","John\r\nDoe","AAA","EQ1","Hammer\r\nXL","Check-Out"`;
   expect(csv).toBe(expected);
   const parsed = parseCSV(csv);
   expect(parsed[1][2]).toBe('John\r\nDoe');
-  expect(parsed[1][4]).toBe('Hammer\r\nXL');
+  expect(parsed[1][5]).toBe('Hammer\r\nXL');
   spy.mockRestore();
 });
 
@@ -138,7 +140,7 @@ test('exportRecordsCSV leaves blank cells for missing fields', () => {
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
   const row = csv.split('\n')[1];
-  expect(row).toBe('"2023-01-01T00:00:00","","","","",""');
+  expect(row).toBe('"2023-01-01T00:00:00","","","","","",""');
   spy.mockRestore();
 });
 

--- a/tests/filterRecords.test.js
+++ b/tests/filterRecords.test.js
@@ -62,8 +62,8 @@ describe('filterRecords', () => {
     win.filterRecords();
     const rows = document.querySelectorAll('#recordsTable table tr');
     expect(rows).toHaveLength(2);
-    expect(rows[1].children[3].textContent).toBe('EQ1');
-    expect(rows[1].children[4].textContent).toBe('Laptop');
+    expect(rows[1].children[4].textContent).toBe('EQ1');
+    expect(rows[1].children[5].textContent).toBe('Laptop');
   });
 
   test('Date filtering returns records with the selected date', () => {


### PR DESCRIPTION
## Summary
- derive station from the first three characters of the badge and store it with each record
- show station in record tables and include it in exported CSV files
- adjust tests to verify station derivation and updated CSV format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abdd494334832b9c05adcb6ca24f08