### PR TITLE
Add away-from-home equipment notifications

### DIFF
--- a/scripts/notifications.js
+++ b/scripts/notifications.js
@@ -61,6 +61,7 @@ function updateNotifications() {
   notificationDiv.className = '';
   notificationDiv.classList.remove('visible');
   const status = {};
+  const lastStation = {};
   const recs = (typeof records !== 'undefined' && Array.isArray(records)) ? records : [];
   recs.forEach(rec => {
     (rec.equipmentBarcodes || []).forEach(code => {
@@ -70,17 +71,33 @@ function updateNotifications() {
       } else if (rec.action === "Check-In") {
         status[code]--;
       }
+      if (rec.station) {
+        lastStation[code] = rec.station;
+      }
     });
   });
   const overdue = [];
+  const away = [];
   for (let code in status) {
     if (status[code] > 0) {
       const name = (equipmentItems[code] && equipmentItems[code].name) || "Unknown Equipment";
       overdue.push(`${code} (${name})`);
     }
   }
-  if (overdue.length > 0) {
-    notificationDiv.textContent = "Overdue Equipment: " + overdue.join(", ");
+  for (let code in lastStation) {
+    const equipment = equipmentItems[code];
+    const home = equipment && equipment.homeStation;
+    const last = lastStation[code];
+    if (home && last && home !== last) {
+      const name = (equipment && equipment.name) || "Unknown Equipment";
+      away.push(`${code} (${name})`);
+    }
+  }
+  const messages = [];
+  if (overdue.length > 0) messages.push("Overdue Equipment: " + overdue.join(", "));
+  if (away.length > 0) messages.push("Equipment Away From Home: " + away.join(", "));
+  if (messages.length > 0) {
+    notificationDiv.textContent = messages.join(" | ");
     notificationDiv.classList.add('visible');
   } else {
     notificationDiv.textContent = "";

--- a/tests/awayFromHomeNotifications.test.js
+++ b/tests/awayFromHomeNotifications.test.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+const scripts = [
+  '../scripts/storage.js',
+  '../scripts/notifications.js',
+  '../scripts/admin.js',
+  '../scripts/csvParser.js',
+  '../scripts/records.js',
+  '../scripts/app.js'
+].map(p => fs.readFileSync(path.resolve(__dirname, p), 'utf8')).join('\n');
+
+function setupDom({ equipmentItems = {}, records = [] } = {}) {
+  const dom = new JSDOM(html, { url: 'http://localhost', runScripts: 'dangerously' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.localStorage = window.localStorage;
+  window.alert = jest.fn();
+  localStorage.setItem('employees', JSON.stringify({}));
+  localStorage.setItem('equipmentItems', JSON.stringify(equipmentItems));
+  localStorage.setItem('records', JSON.stringify(records));
+  window.eval(scripts);
+  return window;
+}
+
+afterEach(() => {
+  delete global.window;
+  delete global.document;
+  delete global.localStorage;
+});
+
+test('shows away-from-home notification', () => {
+  const win = setupDom({
+    equipmentItems: { 'E1': { name: 'Scanner', homeStation: 'A' } },
+    records: [
+      { station: 'B', equipmentBarcodes: ['E1'], action: 'Check-Out' },
+      { station: 'B', equipmentBarcodes: ['E1'], action: 'Check-In' }
+    ]
+  });
+  win.updateNotifications();
+  const notificationDiv = win.document.getElementById('notifications');
+  expect(notificationDiv.textContent).toContain('Equipment Away From Home: E1 (Scanner)');
+  expect(notificationDiv.classList.contains('visible')).toBe(true);
+});
+
+test('clears away-from-home notification when equipment returns home', () => {
+  let win = setupDom({
+    equipmentItems: { 'E1': { name: 'Scanner', homeStation: 'A' } },
+    records: [
+      { station: 'B', equipmentBarcodes: ['E1'], action: 'Check-In' }
+    ]
+  });
+  win.updateNotifications();
+  let notificationDiv = win.document.getElementById('notifications');
+  expect(notificationDiv.textContent).toContain('Equipment Away From Home');
+  win = setupDom({
+    equipmentItems: { 'E1': { name: 'Scanner', homeStation: 'A' } },
+    records: [
+      { station: 'B', equipmentBarcodes: ['E1'], action: 'Check-In' },
+      { station: 'A', equipmentBarcodes: ['E1'], action: 'Check-In' }
+    ]
+  });
+  win.updateNotifications();
+  notificationDiv = win.document.getElementById('notifications');
+  expect(notificationDiv.textContent).toBe('');
+  expect(notificationDiv.classList.contains('visible')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- track each device's last station to warn when equipment is used away from its home location
- show combined overdue/away-from-home banner and add regression tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abde89bc48832bba0d7c85c92895a2