### PR TITLE
Add tests for home station persistence and notifications

### DIFF
--- a/tests/addEquipmentHomeStationPersistence.test.js
+++ b/tests/addEquipmentHomeStationPersistence.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+const scripts = [
+  '../scripts/storage.js',
+  '../scripts/notifications.js',
+  '../scripts/admin.js',
+  '../scripts/csvParser.js',
+  '../scripts/records.js',
+  '../scripts/app.js'
+].map(p => fs.readFileSync(path.resolve(__dirname, p), 'utf8')).join('\n');
+
+function setupDom() {
+  const dom = new JSDOM(html, { url: 'http://localhost', runScripts: 'dangerously' });
+  const { window } = dom;
+  global.window = window;
+  global.document = window.document;
+  global.localStorage = window.localStorage;
+  window.alert = jest.fn();
+  localStorage.setItem('employees', JSON.stringify({}));
+  localStorage.setItem('equipmentItems', JSON.stringify({}));
+  localStorage.setItem('records', JSON.stringify([]));
+  window.eval(scripts);
+  return window;
+}
+
+afterEach(() => {
+  delete global.window;
+  delete global.document;
+  delete global.localStorage;
+});
+
+test('equipment added with home station persists the field', () => {
+  jest.useFakeTimers();
+  const win = setupDom();
+  const { document, localStorage } = win;
+  document.getElementById('equipName').value = 'Scanner';
+  document.getElementById('equipSerial').value = 'E1';
+  document.getElementById('equipStation').value = 'A';
+  win.addEquipmentAdmin();
+  jest.runAllTimers();
+  jest.useRealTimers();
+  const stored = JSON.parse(localStorage.getItem('equipmentItems'));
+  expect(stored).toEqual({ E1: { name: 'Scanner', homeStation: 'A' } });
+});
+

--- a/tests/updateNotificationsHomeStation.test.js
+++ b/tests/updateNotificationsHomeStation.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const { updateNotifications } = require('../scripts/notifications');
+
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+
+function setupDom() {
+  const dom = new JSDOM(html, { url: 'http://localhost' });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  return dom.window;
+}
+
+afterEach(() => {
+  delete global.window;
+  delete global.document;
+  delete global.equipmentItems;
+  delete global.records;
+});
+
+test('updateNotifications flags away-from-home equipment and clears when returned', () => {
+  setupDom();
+  global.equipmentItems = { E1: { name: 'Scanner', homeStation: 'A' } };
+  global.records = [
+    { station: 'B', equipmentBarcodes: ['E1'], action: 'Check-In' }
+  ];
+  updateNotifications();
+  const notificationDiv = document.getElementById('notifications');
+  expect(notificationDiv.textContent).toBe('Equipment Away From Home: E1 (Scanner)');
+  expect(notificationDiv.classList.contains('visible')).toBe(true);
+
+  global.records.push({ station: 'A', equipmentBarcodes: ['E1'], action: 'Check-In' });
+  updateNotifications();
+  expect(notificationDiv.textContent).toBe('');
+  expect(notificationDiv.classList.contains('visible')).toBe(false);
+});
+


### PR DESCRIPTION
## Summary
- test that equipment added with a home station stores that value
- ensure `updateNotifications` flags equipment away from home and clears on return

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abe0385e94832b81a4f894d80378c2