### PR TITLE
Add date picker button for record filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,10 @@
         <label for="recordEquipment" class="sr-only">Search by equipment name or serial</label>
         <input type="text" id="recordEquipment" placeholder="Search by equipment name or serial">
         <label for="recordDate" class="sr-only">Filter by date</label>
-        <input type="date" id="recordDate">
+        <div class="recordDateContainer">
+          <input type="date" id="recordDate" placeholder="Filter by date">
+          <button id="recordDateBtn" type="button"><span class="material-symbols-outlined">calendar_month</span></button>
+        </div>
         <button type="submit" id="filterRecordsBtn" class="btn btn-secondary">Search/Filter</button>
         <button type="button" id="clearFiltersBtn" class="btn btn-secondary">Clear Filters</button>
       </form>

--- a/scripts/records.js
+++ b/scripts/records.js
@@ -254,6 +254,21 @@ function handleImportEquipment(event) {
   reader.readAsText(file);
 }
 
+if (typeof document !== 'undefined') {
+  const recordDateBtn = document.getElementById('recordDateBtn');
+  if (recordDateBtn) {
+    recordDateBtn.addEventListener('click', () => {
+      const dateInput = document.getElementById('recordDate');
+      if (!dateInput) return;
+      if (typeof dateInput.showPicker === 'function') {
+        dateInput.showPicker();
+      } else {
+        dateInput.focus();
+      }
+    });
+  }
+}
+
 const recordsModule = {
   csvEscape,
   escapeHtml,

--- a/styles/main.css
+++ b/styles/main.css
@@ -298,6 +298,30 @@
       flex: 1;
       min-width: 9.375rem;
     }
+    #recordFilterForm .recordDateContainer {
+      display: flex;
+      align-items: center;
+      flex: 1;
+      min-width: 9.375rem;
+      gap: 0.625rem;
+    }
+    #recordFilterForm .recordDateContainer input {
+      flex: 1;
+    }
+    #recordDateBtn {
+      padding: 0.5rem;
+      border: none;
+      border-radius: 0.5rem;
+      background-color: var(--color-accent);
+      color: #fff;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    #recordDateBtn:hover {
+      background-color: #0066cc;
+    }
     #recordFilterForm .btn {
       padding: 0.5rem 0.9375rem;
       border-radius: 0.5rem;

--- a/tests/filterRecords.test.js
+++ b/tests/filterRecords.test.js
@@ -147,4 +147,22 @@ describe('filterRecords', () => {
     expect(rows[1].children[2].textContent).toBe('Alice');
     expect(rows[2].children[2].textContent).toBe('Bob');
   });
+
+  test('recordDateBtn triggers showPicker or focus', () => {
+    const win = loadDom([]);
+    const input = document.getElementById('recordDate');
+    input.showPicker = jest.fn();
+    document.getElementById('recordDateBtn').click();
+    expect(input.showPicker).toHaveBeenCalled();
+
+    input.showPicker = undefined;
+    input.focus = jest.fn();
+    document.getElementById('recordDateBtn').click();
+    expect(input.focus).toHaveBeenCalled();
+  });
+
+  test('recordDate input has placeholder text', () => {
+    loadDom([]);
+    expect(document.getElementById('recordDate').getAttribute('placeholder')).toBe('Filter by date');
+  });
 });


### PR DESCRIPTION
## Summary
- add placeholder and calendar button to records filter form
- trigger date input picker or focus on button press
- style record date picker button and ensure tests cover new behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abe42a8590832b80136473cd3fb67c