### PR TITLE
Normalize station name comparisons

### DIFF
--- a/scripts/notifications.js
+++ b/scripts/notifications.js
@@ -88,7 +88,9 @@ function updateNotifications() {
     const equipment = equipmentItems[code];
     const home = equipment && equipment.homeStation;
     const last = lastStation[code];
-    if (home && last && home !== last) {
+    const homeNorm = typeof home === 'string' ? home.toLowerCase() : home;
+    const lastNorm = typeof last === 'string' ? last.toLowerCase() : last;
+    if (homeNorm && lastNorm && homeNorm !== lastNorm) {
       const name = (equipment && equipment.name) || "Unknown Equipment";
       away.push(`${code} (${name})`);
     }

--- a/tests/updateNotificationsHomeStation.test.js
+++ b/tests/updateNotificationsHomeStation.test.js
@@ -36,3 +36,15 @@ test('updateNotifications flags away-from-home equipment and clears when returne
   expect(notificationDiv.classList.contains('visible')).toBe(false);
 });
 
+test('updateNotifications ignores case differences in station names', () => {
+  setupDom();
+  global.equipmentItems = { E1: { name: 'Scanner', homeStation: 'Alpha' } };
+  global.records = [
+    { station: 'alpha', equipmentBarcodes: ['E1'], action: 'Check-In' }
+  ];
+  updateNotifications();
+  const notificationDiv = document.getElementById('notifications');
+  expect(notificationDiv.textContent).toBe('');
+  expect(notificationDiv.classList.contains('visible')).toBe(false);
+});
+


### PR DESCRIPTION
## Summary
- Make `updateNotifications` compare home and last station names without regard to case
- Add regression test ensuring mixed-case stations don't trigger false 'away from home' notices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abf55b31dc832b9ebd2bc39fcb9112