### PR TITLE
Add home station field to CSV import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Data is stored in the browser's `localStorage`, and CSV files are generated at r
 ### CSV Import/Export
 - Export the activity log as a CSV file from the records view.
 - Import existing employee or equipment lists via CSV through the Admin panel.
+  - Employee CSV columns: `Badge ID`, `Employee Name`, `Home Station` (optional)
+  - Equipment CSV columns: `Equipment Serial`, `Equipment Name`, `Home Station` (optional)
+  - Legacy CSVs without the `Home Station` column default the value to blank
 
 ### Record Filtering
 - Use the search box to filter records by employee, equipment, or date.

--- a/scripts/records.js
+++ b/scripts/records.js
@@ -95,9 +95,9 @@ function exportRecordsCSV() {
 
 function exportEmployeesCSV() {
   let csvContent = "data:text/csv;charset=utf-8,";
-  csvContent += "Badge ID,Employee Name\n";
+  csvContent += "Badge ID,Employee Name,Home Station\n";
   Object.entries(employees).forEach(([badge, info]) => {
-    csvContent += `"${csvEscape(badge)}","${csvEscape(info.name)}"\n`;
+    csvContent += `"${csvEscape(badge)}","${csvEscape(info.name)}","${csvEscape(info.homeStation ?? '')}"\n`;
   });
   const link = document.createElement("a");
   link.href = encodeURI(csvContent);
@@ -109,9 +109,9 @@ function exportEmployeesCSV() {
 
 function exportEquipmentCSV() {
   let csvContent = "data:text/csv;charset=utf-8,";
-  csvContent += "Equipment Serial,Equipment Name\n";
+  csvContent += "Equipment Serial,Equipment Name,Home Station\n";
   Object.entries(equipmentItems).forEach(([serial, info]) => {
-    csvContent += `"${csvEscape(serial)}","${csvEscape(info.name)}"\n`;
+    csvContent += `"${csvEscape(serial)}","${csvEscape(info.name)}","${csvEscape(info.homeStation ?? '')}"\n`;
   });
   const link = document.createElement("a");
   link.href = encodeURI(csvContent);
@@ -170,6 +170,7 @@ function handleImportEmployees(event) {
       }
       let badge = parts[0].replace(/^"|"$/g, '').trim();
       let name = parts[1].replace(/^"|"$/g, '').trim();
+      let homeStation = parts[2] ? parts[2].replace(/^"|"$/g, '').trim() : '';
       if (badge && name) {
         if (employees[badge]) {
           const overwrite = typeof confirm === 'function'
@@ -179,7 +180,7 @@ function handleImportEmployees(event) {
             continue;
           }
         }
-        employees[badge] = { name, homeStation: '' };
+        employees[badge] = { name, homeStation };
       }
     }
     saveToStorage("employees", employees);
@@ -229,6 +230,7 @@ function handleImportEquipment(event) {
       }
       let serial = parts[0].replace(/^"|"$/g, '').trim();
       let name = parts[1].replace(/^"|"$/g, '').trim();
+      let homeStation = parts[2] ? parts[2].replace(/^"|"$/g, '').trim() : '';
       if (serial && name) {
         if (equipmentItems[serial]) {
           const overwrite = typeof confirm === 'function'
@@ -238,7 +240,7 @@ function handleImportEquipment(event) {
             continue;
           }
         }
-        equipmentItems[serial] = { name, homeStation: '' };
+        equipmentItems[serial] = { name, homeStation };
       }
     }
     saveToStorage("equipmentItems", equipmentItems);

--- a/tests/exportCSV.test.js
+++ b/tests/exportCSV.test.js
@@ -41,7 +41,7 @@ test('exportEmployeesCSV escapes quotes in names', () => {
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
   const row = csv.trim().split('\n')[1];
-  expect(row).toBe('"1","John ""JJ"" Doe"');
+  expect(row).toBe('"1","John ""JJ"" Doe",""');
   spy.mockRestore();
 });
 
@@ -52,7 +52,7 @@ test('exportEquipmentCSV escapes quotes in names', () => {
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
   const row = csv.trim().split('\n')[1];
-  expect(row).toBe('"EQ1","Hammer ""XL"""');
+  expect(row).toBe('"EQ1","Hammer ""XL""",""');
   spy.mockRestore();
 });
 
@@ -83,7 +83,7 @@ test('exportEmployeesCSV escapes newline characters in names', () => {
   win.exportEmployeesCSV();
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-  const expected = `Badge ID,Employee Name\n"1","John\r\nDoe"\n`;
+  const expected = `Badge ID,Employee Name,Home Station\n"1","John\r\nDoe",""\n`;
   expect(csv).toBe(expected);
   const parsed = parseCSV(csv);
   expect(parsed[1][1]).toBe('John\r\nDoe');
@@ -96,7 +96,7 @@ test('exportEquipmentCSV escapes newline characters in names', () => {
   win.exportEquipmentCSV();
   const link = spy.mock.calls[0][0];
   const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-  const expected = `Equipment Serial,Equipment Name\n"EQ1","Hammer\r\nXL"\n`;
+  const expected = `Equipment Serial,Equipment Name,Home Station\n"EQ1","Hammer\r\nXL",""\n`;
   expect(csv).toBe(expected);
   const parsed = parseCSV(csv);
   expect(parsed[1][1]).toBe('Hammer\r\nXL');
@@ -144,6 +144,28 @@ test('exportRecordsCSV leaves blank cells for missing fields', () => {
   spy.mockRestore();
 });
 
+test('exportEmployeesCSV includes home station field', () => {
+  const win = setupDom({ employees: { '1': { name: 'John Doe', homeStation: 'STN1' } } });
+  const spy = jest.spyOn(document.body, 'appendChild');
+  win.exportEmployeesCSV();
+  const link = spy.mock.calls[0][0];
+  const csv = decodeURI(link.href).split('charset=utf-8,')[1];
+  const row = csv.trim().split('\n')[1];
+  expect(row).toBe('"1","John Doe","STN1"');
+  spy.mockRestore();
+});
+
+test('exportEquipmentCSV includes home station field', () => {
+  const win = setupDom({ equipmentItems: { 'EQ1': { name: 'Hammer', homeStation: 'H1' } } });
+  const spy = jest.spyOn(document.body, 'appendChild');
+  win.exportEquipmentCSV();
+  const link = spy.mock.calls[0][0];
+  const csv = decodeURI(link.href).split('charset=utf-8,')[1];
+  const row = csv.trim().split('\n')[1];
+  expect(row).toBe('"EQ1","Hammer","H1"');
+  spy.mockRestore();
+});
+
 test('exportEmployeesCSV ignores inherited prototype properties', () => {
   Object.prototype.protoEmployee = 'Prototype';
   try {
@@ -152,7 +174,7 @@ test('exportEmployeesCSV ignores inherited prototype properties', () => {
     win.exportEmployeesCSV();
     const link = spy.mock.calls[0][0];
     const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-    const expected = `Badge ID,Employee Name\n"1","John Doe"\n`;
+    const expected = `Badge ID,Employee Name,Home Station\n"1","John Doe",""\n`;
     expect(csv).toBe(expected);
     spy.mockRestore();
   } finally {
@@ -168,7 +190,7 @@ test('exportEquipmentCSV ignores inherited prototype properties', () => {
     win.exportEquipmentCSV();
     const link = spy.mock.calls[0][0];
     const csv = decodeURI(link.href).split('charset=utf-8,')[1];
-    const expected = `Equipment Serial,Equipment Name\n"EQ1","Hammer"\n`;
+    const expected = `Equipment Serial,Equipment Name,Home Station\n"EQ1","Hammer",""\n`;
     expect(csv).toBe(expected);
     spy.mockRestore();
   } finally {


### PR DESCRIPTION
## Summary
- Parse optional home station column when importing employees or equipment
- Include `Home Station` column in employee and equipment CSV exports
- Document CSV headers and defaulting behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac49ca2108832ba76806977d377c75