### PR TITLE
Highlight checkout tab on load

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -372,3 +372,5 @@ setupDropdown(actionBtn, actionMenu, (value, text) => {
   document.getElementById('action').value = value;
   actionBtn.textContent = text;
 });
+
+showSection('checkout');


### PR DESCRIPTION
### Motivation
- The app did not mark the Check-Out navigation item active on initial load, confusing users about which section is displayed.

### Description
- Call `showSection('checkout')` on startup by adding it to `scripts/app.js` so the Check-Out tab is highlighted and the section shown by default.

### Testing
- Started a local HTTP server and ran a Playwright script to load `http://127.0.0.1:8000` and capture a screenshot, which completed successfully (`artifacts/checkout-active.png`).
- No unit tests were added or run for this trivial UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694ead3240832b96c309d38234d6ae)